### PR TITLE
Fix Dinerclub CI and local test suite

### DIFF
--- a/dinersclub/Dockerfile
+++ b/dinersclub/Dockerfile
@@ -1,10 +1,8 @@
 FROM golang:alpine AS build
-RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories
-RUN apk upgrade --update-cache --available
 RUN apk add --no-cache \
         gcc \
         libc-dev \
-        librdkafka-dev=1.8.0-r0 \
+        librdkafka-dev=1.8.2-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
         pkgconf
 RUN mkdir /app
 WORKDIR /app
@@ -17,11 +15,8 @@ RUN go build -tags dynamic -a -o main .
 
 
 FROM alpine
-RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories
-RUN apk upgrade --update-cache --available
-
 RUN apk add --no-cache \
-        librdkafka-dev=1.8.0-r0
+        librdkafka-dev=1.8.2-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 WORKDIR /app
 COPY --from=build /app/main /app/
 CMD ["/app/main"]

--- a/dinersclub/Dockerfile.dev
+++ b/dinersclub/Dockerfile.dev
@@ -1,11 +1,9 @@
 FROM golang:alpine
 
-RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories
-RUN apk upgrade --update-cache --available
 RUN apk add --no-cache \
     gcc \
     libc-dev \
-    librdkafka-dev=1.8.0-r0 \
+    librdkafka-dev=1.8.2-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
     readline-dev
 
 RUN mkdir /app


### PR DESCRIPTION
Currently, neither CI nor local are able to install `librdkafka-dev=1.8.0-r0`. Seems like _edge_ packages are less _stable_ than anticipated. 

See, https://app.circleci.com/pipelines/github/vlab-research/fly/233/workflows/93ecbf64-fe64-4510-be8e-8167fc393452/jobs/377.

Hopefully, _pinning_ the repository directly using `--repository`  (`apk add xxx --repository=xxx`) will do the trick.