### PR TITLE
Bugfix/logic jumps

### DIFF
--- a/websurvey/lib/typewheels/form.js
+++ b/websurvey/lib/typewheels/form.js
@@ -99,9 +99,13 @@ function getFieldValue(qa, ref) {
 
   // return null if there are no matches,
   // or if there are no answers,
-  const ans = match && match[1];
+  // otherwise return match even if empty string
 
-  return ans ? ans : null;
+  if (!match) {
+    return null;
+  } else {
+    return match[1];
+  }
 }
 
 function getVar(ctx, qa, ref, vars, v) {
@@ -113,9 +117,6 @@ function getVar(ctx, qa, ref, vars, v) {
   const { type, value } = v;
 
   if (type === "constant") {
-    if (value === "") {
-      return null;
-    }
     return value;
   }
 

--- a/websurvey/lib/typewheels/form.js
+++ b/websurvey/lib/typewheels/form.js
@@ -62,8 +62,8 @@ const funs = {
   lower_equal_than: (a, b) => a <= b,
   is: (a, b) => a === b,
   equal: (a, b) => a === b,
-  is_not: (a, b) => a != b,
-  not_equal: (a, b) => a != b,
+  is_not: (a, b) => a !== b,
+  not_equal: (a, b) => a !== b,
 };
 
 function getCondition(ctx, qa, ref, { op, vars }) {
@@ -113,6 +113,9 @@ function getVar(ctx, qa, ref, vars, v) {
   const { type, value } = v;
 
   if (type === "constant") {
+    if (value === "") {
+      return null;
+    }
     return value;
   }
 

--- a/websurvey/lib/typewheels/form.js
+++ b/websurvey/lib/typewheels/form.js
@@ -62,8 +62,8 @@ const funs = {
   lower_equal_than: (a, b) => a <= b,
   is: (a, b) => a === b,
   equal: (a, b) => a === b,
-  is_not: (a, b) => a !== b,
-  not_equal: (a, b) => a !== b,
+  is_not: (a, b) => a != b,
+  not_equal: (a, b) => a != b,
 };
 
 function getCondition(ctx, qa, ref, { op, vars }) {
@@ -100,6 +100,7 @@ function getFieldValue(qa, ref) {
   // return null if there are no matches,
   // or if there are no answers,
   const ans = match && match[1];
+
   return ans ? ans : null;
 }
 
@@ -159,7 +160,7 @@ function getDynamicValue(qa, title) {
     return false;
   }
 
-  if (!fieldValue || fieldValue === " ") {
+  if (!fieldValue) {
     throw new TypeError(
       `Trying to interpolate a non-existent field value: ${title}`
     );

--- a/websurvey/lib/typewheels/form.test.js
+++ b/websurvey/lib/typewheels/form.test.js
@@ -93,38 +93,38 @@ describe("getVar", () => {
 });
 
 describe("getCondition", () => {
-  // const cond = {
-  //   op: "always",
-  //   vars: [
-  //     { type: "field", value: "baz" },
-  //     { type: "constant", value: 10 },
-  //   ],
-  // };
+  const cond = {
+    op: "always",
+    vars: [
+      { type: "field", value: "baz" },
+      { type: "constant", value: 10 },
+    ],
+  };
 
-  // it("works with always true", () => {
-  //   f.getCondition({ form }, [], "", cond).should.be.true;
-  // });
+  it("works with always true", () => {
+    f.getCondition({ form }, [], "", cond).should.be.true;
+  });
 
-  // it("works with string equals", () => {
-  //   const cond = {
-  //     op: "equal",
-  //     vars: [
-  //       { type: "field", value: "whats_your_name" },
-  //       { type: "constant", value: "baz" },
-  //     ],
-  //   };
+  it("works with string equals", () => {
+    const cond = {
+      op: "equal",
+      vars: [
+        { type: "field", value: "whats_your_name" },
+        { type: "constant", value: "baz" },
+      ],
+    };
 
-  //   const ref = "whats_your_name";
+    const ref = "whats_your_name";
 
-  //   const qaGood = [["whats_your_name", "baz"]];
-  //   const qaBad = [["whats_your_name", ""]];
+    const qaGood = [["whats_your_name", "baz"]];
+    const qaBad = [["whats_your_name", ""]];
 
-  //   f.getCondition({ form }, qaGood, ref, cond).should.be.true;
-  //   f.getCondition({ form }, qaGood, ref, { ...cond, op: "is" }).should.be.true;
-  //   f.getCondition({ form }, qaBad, ref, cond).should.be.false;
-  //   f.getCondition({ form }, qaBad, ref, { ...cond, op: "is_not" }).should.be
-  //     .true;
-  // });
+    f.getCondition({ form }, qaGood, ref, cond).should.be.true;
+    f.getCondition({ form }, qaGood, ref, { ...cond, op: "is" }).should.be.true;
+    f.getCondition({ form }, qaBad, ref, cond).should.be.false;
+    f.getCondition({ form }, qaBad, ref, { ...cond, op: "is_not" }).should.be
+      .true;
+  });
 
   it("works with string not equals", () => {
     const cond = {
@@ -148,170 +148,170 @@ describe("getCondition", () => {
       .false;
   });
 
-  //   it("works with number equals and not equals is and is not - casts types from strings", () => {
-  //     const cond = {
-  //       op: "is",
-  //       vars: [
-  //         { type: "field", value: "baz" },
-  //         { type: "constant", value: 10 },
-  //       ],
-  //     };
+  it("works with number equals and not equals is and is not - casts types from strings", () => {
+    const cond = {
+      op: "is",
+      vars: [
+        { type: "field", value: "baz" },
+        { type: "constant", value: 10 },
+      ],
+    };
 
-  //     const qa = [["baz", "10"]];
+    const qa = [["baz", "10"]];
 
-  //     f.getCondition({ form }, qa, "", cond).should.be.true;
-  //     f.getCondition({ form }, qa, "", { ...cond, op: "equal" }).should.be.true;
-  //     f.getCondition({ form }, qa, "", { ...cond, op: "is_not" }).should.be.false;
-  //     f.getCondition({ form }, qa, "", { ...cond, op: "not_equal" }).should.be
-  //       .false;
-  //   });
+    f.getCondition({ form }, qa, "", cond).should.be.true;
+    f.getCondition({ form }, qa, "", { ...cond, op: "equal" }).should.be.true;
+    f.getCondition({ form }, qa, "", { ...cond, op: "is_not" }).should.be.false;
+    f.getCondition({ form }, qa, "", { ...cond, op: "not_equal" }).should.be
+      .false;
+  });
 
-  //   it("works with number not equals - type casting!", () => {
-  //     const cond = {
-  //       op: "is",
-  //       vars: [
-  //         { type: "field", value: "baz" },
-  //         { type: "constant", value: 10 },
-  //       ],
-  //     };
+  it("works with number not equals - type casting!", () => {
+    const cond = {
+      op: "is",
+      vars: [
+        { type: "field", value: "baz" },
+        { type: "constant", value: 10 },
+      ],
+    };
 
-  //     const qa = [["baz", "11"]];
+    const qa = [["baz", "11"]];
 
-  //     f.getCondition({ form }, qa, "", cond).should.be.false;
-  //   });
+    f.getCondition({ form }, qa, "", cond).should.be.false;
+  });
 
-  //   it("works with lower_equal_than operator on numbers", () => {
-  //     const cond = {
-  //       op: "lower_equal_than",
-  //       vars: [
-  //         { type: "field", value: "baz" },
-  //         { type: "constant", value: 10 },
-  //       ],
-  //     };
+  it("works with lower_equal_than operator on numbers", () => {
+    const cond = {
+      op: "lower_equal_than",
+      vars: [
+        { type: "field", value: "baz" },
+        { type: "constant", value: 10 },
+      ],
+    };
 
-  //     const qa = [["baz", "10"]];
+    const qa = [["baz", "10"]];
 
-  //     f.getCondition({ form }, qa, "", cond).should.be.true;
-  //     f.getCondition({ form }, qa, "", { ...cond, op: "greater_equal_than" })
-  //       .should.be.true;
-  //   });
+    f.getCondition({ form }, qa, "", cond).should.be.true;
+    f.getCondition({ form }, qa, "", { ...cond, op: "greater_equal_than" })
+      .should.be.true;
+  });
 
-  //   it('works with "and" and "or" operators', () => {
-  //     const cond = {
-  //       op: "and",
-  //       vars: [
-  //         {
-  //           op: "is",
-  //           vars: [
-  //             {
-  //               type: "field",
-  //               value: "baz",
-  //             },
-  //             {
-  //               type: "constant",
-  //               value: true,
-  //             },
-  //           ],
-  //         },
-  //         {
-  //           op: "is",
-  //           vars: [
-  //             {
-  //               type: "field",
-  //               value: "qux",
-  //             },
-  //             {
-  //               type: "constant",
-  //               value: true,
-  //             },
-  //           ],
-  //         },
-  //       ],
-  //     };
+  it('works with "and" and "or" operators', () => {
+    const cond = {
+      op: "and",
+      vars: [
+        {
+          op: "is",
+          vars: [
+            {
+              type: "field",
+              value: "baz",
+            },
+            {
+              type: "constant",
+              value: true,
+            },
+          ],
+        },
+        {
+          op: "is",
+          vars: [
+            {
+              type: "field",
+              value: "qux",
+            },
+            {
+              type: "constant",
+              value: true,
+            },
+          ],
+        },
+      ],
+    };
 
-  //     const qa = [
-  //       ["baz", true],
-  //       ["qux", true],
-  //     ];
-  //     const qa2 = [
-  //       ["baz", true],
-  //       ["qux", false],
-  //     ];
+    const qa = [
+      ["baz", true],
+      ["qux", true],
+    ];
+    const qa2 = [
+      ["baz", true],
+      ["qux", false],
+    ];
 
-  //     f.getCondition({ form }, qa, "", cond).should.be.true;
-  //     f.getCondition({ form }, qa, "", { ...cond, op: "or" }).should.be.true;
-  //     f.getCondition({ form }, qa2, "", cond).should.be.false;
-  //     f.getCondition({ form }, qa2, "", { ...cond, op: "or" }).should.be.true;
-  //   });
+    f.getCondition({ form }, qa, "", cond).should.be.true;
+    f.getCondition({ form }, qa, "", { ...cond, op: "or" }).should.be.true;
+    f.getCondition({ form }, qa2, "", cond).should.be.false;
+    f.getCondition({ form }, qa2, "", { ...cond, op: "or" }).should.be.true;
+  });
 });
 
-// describe("jump", () => {
-//   it("makes jump when required and makes no jump when not", () => {
-//     const logic = {
-//       type: "field",
-//       ref: "whats_your_name",
-//       actions: [
-//         {
-//           action: "jump",
-//           details: {
-//             to: {
-//               type: "field",
-//               value: "how_is_your_day",
-//             },
-//           },
-//           condition: {
-//             op: "not_equal",
-//             vars: [
-//               {
-//                 type: "field",
-//                 value: "whats_your_name",
-//               },
-//               {
-//                 type: "constant",
-//                 value: "",
-//               },
-//             ],
-//           },
-//         },
-//       ],
-//     };
+describe("jump", () => {
+  it("makes jump when required and makes no jump when not", () => {
+    const logic = {
+      type: "field",
+      ref: "whats_your_name",
+      actions: [
+        {
+          action: "jump",
+          details: {
+            to: {
+              type: "field",
+              value: "how_is_your_day",
+            },
+          },
+          condition: {
+            op: "not_equal",
+            vars: [
+              {
+                type: "field",
+                value: "whats_your_name",
+              },
+              {
+                type: "constant",
+                value: "",
+              },
+            ],
+          },
+        },
+      ],
+    };
 
-//     const qaGood = [["whats_your_name", "baz"]];
-//     const qaBad = [["whats_your_name", ""]];
+    const qaGood = [["whats_your_name", "baz"]];
+    const qaBad = [["whats_your_name", ""]];
 
-//     // const yes = f.jump(form, qaGood, logic);
-//     // yes.should.equal("how_is_your_day");
+    // const yes = f.jump(form, qaGood, logic);
+    // yes.should.equal("how_is_your_day");
 
-//     const no = f.jump(form, qaBad, logic);
-//     no.should.equal("whats_your_age");
-//   });
-// });
+    const no = f.jump(form, qaBad, logic);
+    no.should.equal("whats_your_age");
+  });
+});
 
-// describe("getNextField", () => {
-//   it("gets the next field in the form taking into account any logic jumps", () => {
-//     const ref = "whats_your_name";
-//     const qaGood = [[ref, "baz"]];
-//     const qaBad = [[ref, ""]];
+describe("getNextField", () => {
+  it("gets the next field in the form taking into account any logic jumps", () => {
+    const ref = "whats_your_name";
+    const qaGood = [[ref, "baz"]];
+    const qaBad = [[ref, ""]];
 
-//     const yes = f.getNextField(form, qaGood, ref);
-//     yes.should.equal(form.fields[2]);
+    const yes = f.getNextField(form, qaGood, ref);
+    yes.should.equal(form.fields[2]);
 
-//     const no = f.getNextField(form, qaBad, ref);
-//     no.should.equal(form.fields[1]);
-//   });
+    const no = f.getNextField(form, qaBad, ref);
+    no.should.equal(form.fields[1]);
+  });
 
-//   it("gets the next field including any thankyou screens", () => {
-//     const ref = "how_is_your_day";
-//     const qaGood = [[ref, "Just OK..."]];
-//     const qaBad = [[ref, ""]];
+  it("gets the next field including any thankyou screens", () => {
+    const ref = "how_is_your_day";
+    const qaGood = [[ref, "Just OK..."]];
+    const qaBad = [[ref, ""]];
 
-//     const yes = f.getNextField(form, qaGood, ref);
-//     yes.should.equal(form.fields[3]);
+    const yes = f.getNextField(form, qaGood, ref);
+    yes.should.equal(form.fields[3]);
 
-//     const no = f.getNextField(form, qaBad, ref);
-//     no.should.equal(form.fields[3]);
-//   });
-// });
+    const no = f.getNextField(form, qaBad, ref);
+    no.should.equal(form.fields[3]);
+  });
+});
 
 describe("translateForm", () => {
   it("forms one array of fields and thankyou screens", () => {

--- a/websurvey/lib/typewheels/form.test.js
+++ b/websurvey/lib/typewheels/form.test.js
@@ -54,6 +54,12 @@ describe("getFieldValue", () => {
     const value = f.getFieldValue(qa, "foo");
     should.not.exist(value);
   });
+
+  it("returns an empty string if the field exists but no answer is given", () => {
+    const qa = [["foo", ""]];
+    const value = f.getFieldValue(qa, "foo");
+    value.should.equal("");
+  });
 });
 
 describe("getChoiceValue", () => {
@@ -88,7 +94,7 @@ describe("getVar", () => {
     const value = f.getVar(ctx, qa, ref, vars, v);
     const value2 = f.getVar(ctx, qa, ref, vars, v2);
     value.should.equal("baz");
-    should.not.exist(value2);
+    value2.should.equal("");
   });
 });
 

--- a/websurvey/lib/typewheels/form.test.js
+++ b/websurvey/lib/typewheels/form.test.js
@@ -279,8 +279,8 @@ describe("jump", () => {
     const qaGood = [["whats_your_name", "baz"]];
     const qaBad = [["whats_your_name", ""]];
 
-    // const yes = f.jump(form, qaGood, logic);
-    // yes.should.equal("how_is_your_day");
+    const yes = f.jump(form, qaGood, logic);
+    yes.should.equal("how_is_your_day");
 
     const no = f.jump(form, qaBad, logic);
     no.should.equal("whats_your_age");

--- a/websurvey/lib/typewheels/form.test.js
+++ b/websurvey/lib/typewheels/form.test.js
@@ -73,189 +73,245 @@ describe("getVar", () => {
     const ctx = form;
     const qa = [["whats_your_name", "baz"]];
     const ref = "whats_your_name";
-    const vars = ctx.logic[0].actions[0].condition.vars;
+    const vars = [
+      {
+        type: "field",
+        value: "whats_your_name",
+      },
+      {
+        type: "constant",
+        value: "",
+      },
+    ];
     const v = vars[0];
     const v2 = vars[1];
     const value = f.getVar(ctx, qa, ref, vars, v);
     const value2 = f.getVar(ctx, qa, ref, vars, v2);
     value.should.equal("baz");
-    value2.should.equal(" ");
+    value2.should.equal("");
   });
 });
 
 describe("getCondition", () => {
-  const cond = {
-    op: "always",
-    vars: [
-      { type: "field", value: "baz" },
-      { type: "constant", value: 10 },
-    ],
-  };
+  // const cond = {
+  //   op: "always",
+  //   vars: [
+  //     { type: "field", value: "baz" },
+  //     { type: "constant", value: 10 },
+  //   ],
+  // };
 
-  it("works with always true", () => {
-    f.getCondition({ form }, [], "", cond).should.be.true;
-  });
+  // it("works with always true", () => {
+  //   f.getCondition({ form }, [], "", cond).should.be.true;
+  // });
 
-  it("works with string equals and not equals, is and is not", () => {
+  // it("works with string equals", () => {
+  //   const cond = {
+  //     op: "equal",
+  //     vars: [
+  //       { type: "field", value: "whats_your_name" },
+  //       { type: "constant", value: "baz" },
+  //     ],
+  //   };
+
+  //   const ref = "whats_your_name";
+
+  //   const qaGood = [["whats_your_name", "baz"]];
+  //   const qaBad = [["whats_your_name", ""]];
+
+  //   f.getCondition({ form }, qaGood, ref, cond).should.be.true;
+  //   f.getCondition({ form }, qaGood, ref, { ...cond, op: "is" }).should.be.true;
+  //   f.getCondition({ form }, qaBad, ref, cond).should.be.false;
+  //   f.getCondition({ form }, qaBad, ref, { ...cond, op: "is_not" }).should.be
+  //     .true;
+  // });
+
+  it("works with string not equals", () => {
     const cond = {
       op: "not_equal",
       vars: [
         { type: "field", value: "whats_your_name" },
-        { type: "constant", value: " " },
+        { type: "constant", value: "" },
       ],
     };
 
-    const qa = [["whats_your_name", "baz"]];
-    const qa2 = [["whats_your_name", " "]];
+    const ref = "whats_your_name";
 
-    f.getCondition({ form }, qa, "whats_your_name", cond).should.be.true;
-    f.getCondition({ form }, qa, "whats_your_name", { ...cond, op: "is_not" })
-      .should.be.true;
-    f.getCondition({ form }, qa, "whats_your_name", { ...cond, op: "is" })
-      .should.be.false;
-    f.getCondition({ form }, qa, "whats_your_name", { ...cond, op: "equal" })
-      .should.be.false;
-    f.getCondition({ form }, qa2, "whats_your_name", cond).should.be.false;
-    f.getCondition({ form }, qa2, "whats_your_name", { ...cond, op: "equal" })
-      .should.be.true;
-  });
+    const qaGood = [["whats_your_name", "baz"]];
+    const qaBad = [["whats_your_name", ""]];
 
-  it("works with number equals and not equals is and is not - casts types from strings", () => {
-    const cond = {
-      op: "is",
-      vars: [
-        { type: "field", value: "baz" },
-        { type: "constant", value: 10 },
-      ],
-    };
-
-    const qa = [["baz", "10"]];
-
-    f.getCondition({ form }, qa, "", cond).should.be.true;
-    f.getCondition({ form }, qa, "", { ...cond, op: "equal" }).should.be.true;
-    f.getCondition({ form }, qa, "", { ...cond, op: "is_not" }).should.be.false;
-    f.getCondition({ form }, qa, "", { ...cond, op: "not_equal" }).should.be
+    f.getCondition({ form }, qaGood, ref, cond).should.be.true;
+    f.getCondition({ form }, qaGood, ref, { ...cond, op: "is" }).should.be
+      .false;
+    f.getCondition({ form }, qaBad, ref, cond).should.be.false;
+    f.getCondition({ form }, qaBad, ref, { ...cond, op: "is_not" }).should.be
       .false;
   });
 
-  it("works with number not equals - type casting!", () => {
-    const cond = {
-      op: "is",
-      vars: [
-        { type: "field", value: "baz" },
-        { type: "constant", value: 10 },
-      ],
-    };
+  //   it("works with number equals and not equals is and is not - casts types from strings", () => {
+  //     const cond = {
+  //       op: "is",
+  //       vars: [
+  //         { type: "field", value: "baz" },
+  //         { type: "constant", value: 10 },
+  //       ],
+  //     };
 
-    const qa = [["baz", "11"]];
+  //     const qa = [["baz", "10"]];
 
-    f.getCondition({ form }, qa, "", cond).should.be.false;
-  });
+  //     f.getCondition({ form }, qa, "", cond).should.be.true;
+  //     f.getCondition({ form }, qa, "", { ...cond, op: "equal" }).should.be.true;
+  //     f.getCondition({ form }, qa, "", { ...cond, op: "is_not" }).should.be.false;
+  //     f.getCondition({ form }, qa, "", { ...cond, op: "not_equal" }).should.be
+  //       .false;
+  //   });
 
-  it("works with lower_equal_than operator on numbers", () => {
-    const cond = {
-      op: "lower_equal_than",
-      vars: [
-        { type: "field", value: "baz" },
-        { type: "constant", value: 10 },
-      ],
-    };
+  //   it("works with number not equals - type casting!", () => {
+  //     const cond = {
+  //       op: "is",
+  //       vars: [
+  //         { type: "field", value: "baz" },
+  //         { type: "constant", value: 10 },
+  //       ],
+  //     };
 
-    const qa = [["baz", "10"]];
+  //     const qa = [["baz", "11"]];
 
-    f.getCondition({ form }, qa, "", cond).should.be.true;
-    f.getCondition({ form }, qa, "", { ...cond, op: "greater_equal_than" })
-      .should.be.true;
-  });
+  //     f.getCondition({ form }, qa, "", cond).should.be.false;
+  //   });
 
-  it('works with "and" and "or" operators', () => {
-    const cond = {
-      op: "and",
-      vars: [
-        {
-          op: "is",
-          vars: [
-            {
-              type: "field",
-              value: "baz",
-            },
-            {
-              type: "constant",
-              value: true,
-            },
-          ],
-        },
-        {
-          op: "is",
-          vars: [
-            {
-              type: "field",
-              value: "qux",
-            },
-            {
-              type: "constant",
-              value: true,
-            },
-          ],
-        },
-      ],
-    };
+  //   it("works with lower_equal_than operator on numbers", () => {
+  //     const cond = {
+  //       op: "lower_equal_than",
+  //       vars: [
+  //         { type: "field", value: "baz" },
+  //         { type: "constant", value: 10 },
+  //       ],
+  //     };
 
-    const qa = [
-      ["baz", true],
-      ["qux", true],
-    ];
-    const qa2 = [
-      ["baz", true],
-      ["qux", false],
-    ];
+  //     const qa = [["baz", "10"]];
 
-    f.getCondition({ form }, qa, "", cond).should.be.true;
-    f.getCondition({ form }, qa, "", { ...cond, op: "or" }).should.be.true;
-    f.getCondition({ form }, qa2, "", cond).should.be.false;
-    f.getCondition({ form }, qa2, "", { ...cond, op: "or" }).should.be.true;
-  });
+  //     f.getCondition({ form }, qa, "", cond).should.be.true;
+  //     f.getCondition({ form }, qa, "", { ...cond, op: "greater_equal_than" })
+  //       .should.be.true;
+  //   });
+
+  //   it('works with "and" and "or" operators', () => {
+  //     const cond = {
+  //       op: "and",
+  //       vars: [
+  //         {
+  //           op: "is",
+  //           vars: [
+  //             {
+  //               type: "field",
+  //               value: "baz",
+  //             },
+  //             {
+  //               type: "constant",
+  //               value: true,
+  //             },
+  //           ],
+  //         },
+  //         {
+  //           op: "is",
+  //           vars: [
+  //             {
+  //               type: "field",
+  //               value: "qux",
+  //             },
+  //             {
+  //               type: "constant",
+  //               value: true,
+  //             },
+  //           ],
+  //         },
+  //       ],
+  //     };
+
+  //     const qa = [
+  //       ["baz", true],
+  //       ["qux", true],
+  //     ];
+  //     const qa2 = [
+  //       ["baz", true],
+  //       ["qux", false],
+  //     ];
+
+  //     f.getCondition({ form }, qa, "", cond).should.be.true;
+  //     f.getCondition({ form }, qa, "", { ...cond, op: "or" }).should.be.true;
+  //     f.getCondition({ form }, qa2, "", cond).should.be.false;
+  //     f.getCondition({ form }, qa2, "", { ...cond, op: "or" }).should.be.true;
+  //   });
 });
 
-describe("jump", () => {
-  it("makes jump when required and makes no jump when not", () => {
-    const logic = form.logic[0];
-    const qaGood = [["whats_your_name", "baz"]];
-    const qaBad = [["whats_your_name", " "]];
+// describe("jump", () => {
+//   it("makes jump when required and makes no jump when not", () => {
+//     const logic = {
+//       type: "field",
+//       ref: "whats_your_name",
+//       actions: [
+//         {
+//           action: "jump",
+//           details: {
+//             to: {
+//               type: "field",
+//               value: "how_is_your_day",
+//             },
+//           },
+//           condition: {
+//             op: "not_equal",
+//             vars: [
+//               {
+//                 type: "field",
+//                 value: "whats_your_name",
+//               },
+//               {
+//                 type: "constant",
+//                 value: "",
+//               },
+//             ],
+//           },
+//         },
+//       ],
+//     };
 
-    const yes = f.jump(form, qaGood, logic);
-    yes.should.equal("how_is_your_day");
+//     const qaGood = [["whats_your_name", "baz"]];
+//     const qaBad = [["whats_your_name", ""]];
 
-    const no = f.jump(form, qaBad, logic);
-    no.should.equal("whats_your_age");
-  });
-});
+//     // const yes = f.jump(form, qaGood, logic);
+//     // yes.should.equal("how_is_your_day");
 
-describe("getNextField", () => {
-  it("gets the next field in the form taking into account any logic jumps", () => {
-    const ref = "whats_your_name";
-    const qaGood = [[ref, "baz"]];
-    const qaBad = [[ref, " "]];
+//     const no = f.jump(form, qaBad, logic);
+//     no.should.equal("whats_your_age");
+//   });
+// });
 
-    const yes = f.getNextField(form, qaGood, ref);
-    yes.should.equal(form.fields[2]);
+// describe("getNextField", () => {
+//   it("gets the next field in the form taking into account any logic jumps", () => {
+//     const ref = "whats_your_name";
+//     const qaGood = [[ref, "baz"]];
+//     const qaBad = [[ref, ""]];
 
-    const no = f.getNextField(form, qaBad, ref);
-    no.should.equal(form.fields[1]);
-  });
+//     const yes = f.getNextField(form, qaGood, ref);
+//     yes.should.equal(form.fields[2]);
 
-  it("gets the next field including any thankyou screens", () => {
-    const ref = "how_is_your_day";
-    const qaGood = [[ref, "Just OK..."]];
-    const qaBad = [[ref, " "]];
+//     const no = f.getNextField(form, qaBad, ref);
+//     no.should.equal(form.fields[1]);
+//   });
 
-    const yes = f.getNextField(form, qaGood, ref);
-    yes.should.equal(form.fields[3]);
+//   it("gets the next field including any thankyou screens", () => {
+//     const ref = "how_is_your_day";
+//     const qaGood = [[ref, "Just OK..."]];
+//     const qaBad = [[ref, ""]];
 
-    const no = f.getNextField(form, qaBad, ref);
-    no.should.equal(form.fields[3]);
-  });
-});
+//     const yes = f.getNextField(form, qaGood, ref);
+//     yes.should.equal(form.fields[3]);
+
+//     const no = f.getNextField(form, qaBad, ref);
+//     no.should.equal(form.fields[3]);
+//   });
+// });
 
 describe("translateForm", () => {
   it("forms one array of fields and thankyou screens", () => {
@@ -291,7 +347,7 @@ describe("getDynamicValue", () => {
   });
 
   it("throws if an invalid field value is found", () => {
-    const qa = [["whats_your_name", " "]];
+    const qa = [["whats_your_name", ""]];
     const title =
       "Nice to meet you, {{field:whats_your_name}}, how is your day going?";
     const fn = () => f.getDynamicValue(qa, title);

--- a/websurvey/lib/typewheels/form.test.js
+++ b/websurvey/lib/typewheels/form.test.js
@@ -88,7 +88,7 @@ describe("getVar", () => {
     const value = f.getVar(ctx, qa, ref, vars, v);
     const value2 = f.getVar(ctx, qa, ref, vars, v2);
     value.should.equal("baz");
-    value2.should.equal("");
+    should.not.exist(value2);
   });
 });
 

--- a/websurvey/lib/typewheels/responseStore.test.js
+++ b/websurvey/lib/typewheels/responseStore.test.js
@@ -53,8 +53,8 @@ describe("next", () => {
       },
     };
 
-    const fieldValue = " ";
-    const qa = [["whats_your_name", " "]];
+    const fieldValue = "";
+    const qa = [["whats_your_name", ""]];
     const ref = "whats_your_name";
     const required = field.validations.required;
     const value = responseStore.next(
@@ -103,7 +103,7 @@ describe("next", () => {
     };
 
     const fieldValue = "foo";
-    const qa = [["whats_your_name", " "]];
+    const qa = [["whats_your_name", ""]];
     const ref = field.ref;
     const required = field.validations.required;
     const res = responseStore.next(form, qa, ref, field, fieldValue, required);

--- a/websurvey/lib/typewheels/validator.test.js
+++ b/websurvey/lib/typewheels/validator.test.js
@@ -117,7 +117,7 @@ describe("validateFieldValue", () => {
   });
 
   it("evaluates to false if the user submits an empty answer to a required question", () => {
-    let field = {
+    const field = {
       type: "short_text",
       title: "foo",
       ref: "foo",

--- a/websurvey/lib/typewheels/validator.test.js
+++ b/websurvey/lib/typewheels/validator.test.js
@@ -117,13 +117,13 @@ describe("validateFieldValue", () => {
   });
 
   it("evaluates to false if the user submits an empty answer to a required question", () => {
-    const field = {
+    let field = {
       type: "short_text",
       title: "foo",
       ref: "foo",
       validations: { required: true },
     };
-    const fieldValue = " ";
+    const fieldValue = "";
     const required = field.validations.required;
 
     let res = v.validateFieldValue(field, fieldValue, required);
@@ -138,7 +138,7 @@ describe("validateFieldValue", () => {
       ref: "foo",
       validations: { required: false },
     };
-    const fieldValue = " ";
+    const fieldValue = "";
     const required = field.validations.required;
 
     let res = v.validateFieldValue(field, fieldValue, required);

--- a/websurvey/mocks/sample.json
+++ b/websurvey/mocks/sample.json
@@ -67,7 +67,7 @@
       "ref": "whats_your_name",
       "properties": {},
       "validations": {
-        "required": false
+        "required": true
       },
       "type": "short_text",
       "attachment": {
@@ -147,7 +147,7 @@
               },
               {
                 "type": "constant",
-                "value": " "
+                "value": ""
               }
             ]
           }

--- a/websurvey/mocks/sample.json
+++ b/websurvey/mocks/sample.json
@@ -67,7 +67,7 @@
       "ref": "whats_your_name",
       "properties": {},
       "validations": {
-        "required": true
+        "required": false
       },
       "type": "short_text",
       "attachment": {

--- a/websurvey/src/routes/Form.svelte
+++ b/websurvey/src/routes/Form.svelte
@@ -80,7 +80,7 @@
                     bind:fieldValue
                     on:add-field-value={addFieldValue} />
             {:else}
-                <Thankyou {field} {title} />
+                <Thankyou {title} />
             {/if}
             <button class="btn">OK</button>
         </div>


### PR DESCRIPTION
### What changes have you made?
- The default value of `fieldValue` has been updated from `" "` to `""` which caused a breaking change in the logic jumps when `fieldValue` is just an empty string
- The breaking change has been fixed by adding in an extra check at `getVar` that says if var `type` is `constant` and is equal to `""`, then return `null`
- This means that the return value of `getCondition` with an `op` of `not_equal` now evaluates to the correct boolean which is `false` because a var `value` of `null` is indeed equal to an empty `fieldValue` , in other words, `null`

### Which issue(s) does this PR address?
#52

### How to test
- Submit a test answer on the first question and make sure the logic jump occurs by taking you to question 3
- Try submitting an empty answer on the first question – the survey should still navigate to question 2 as an answer is not required
- When moving from question 2 to question 3, an error should throw in the console because the validator is trying to interpolate an empty `fieldValue` from question 1

### TODO
- From a UI standpoint we need a workaround for interpolating non-existent field values. Is there ever a use case for allowing questions to be non-required if they are later used for interpolation? 
