### PR TITLE
Optimise abstraction of replybot into web survey

### DIFF
--- a/websurvey/lib/typewheels/form.js
+++ b/websurvey/lib/typewheels/form.js
@@ -1,10 +1,115 @@
 const yaml = require("js-yaml");
-const Mustache = require("mustache");
+const mustache = require("mustache");
 const _ = require("lodash");
-
+const {
+  translator,
+  addCustomType,
+} = require("@vlab-research/translate-typeform");
 class FieldError extends Error {}
 
-function getField(form, ref) {
+// TODO: move this to VALIDATORS somewhere
+// function formValidator(form){
+//   if (!form.fields.length) {
+//     throw new TypeError('This Typeform does not have any fields!')
+//   }
+// }
+
+function getSeed(md, key) {
+  const [__, match] = /seed_(\d+)/.exec(key);
+  const seeds = +match;
+  return (md.seed % seeds) + 1;
+}
+
+// METADATA consists of:
+// 1. Anything on the user object (id, name, first_name, last_name)
+// 2. Anything sent in the original url "ref" query param (i.e. form, via ?ref=form.foo)
+// 3. A random seed, given by 'seed_2' or 'seed_7' or 'seed_N' for any number needed
+function getFromMetadata(ctx, key) {
+  const { user, md } = ctx;
+
+  if (/seed_/.test(key)) return getSeed(md, key);
+
+  const meta = { ...user, ...md };
+
+  if (meta[key] === undefined) {
+    throw new TypeError(
+      `Cannot create field text as the value ${key} does not exist in metadata ${util.inspect(
+        meta
+      )}`
+    );
+  }
+
+  return meta[key];
+}
+
+function getDynamicValue(ctx, qa, v) {
+  const [loc, key] = v.split(":");
+
+  const val =
+    loc === "hidden" ? getFromMetadata(ctx, key) : getFieldValue(qa, key);
+
+  if (!val) {
+    throw new TypeError(`Trying to interpolate a non-existent value: ${v}`);
+  }
+
+  return val;
+}
+
+function _zip(a, b) {
+  // zips two arrays together, alternating, starting with a
+  if (!a || !b) return a.concat(b);
+  const len = a.length + b.length;
+  const arr = [];
+  for (let i = 0; i < len; i++) {
+    i % 2 ? arr.push(b.shift()) : arr.push(a.shift());
+  }
+  return arr;
+}
+
+function _splitUrls(s) {
+  const re = RegExp(/https?:\/\/[^\s]+/gi);
+  const nonMatches = s.split(re).map(s => ["text", s]);
+  if (re.test(s)) {
+    const matches = s.match(re).map(s => ["url", s]);
+    return _zip(nonMatches, matches).filter(a => !!a[1]);
+  }
+  return nonMatches;
+}
+
+function _interpolate(ctx, qa, s, encode) {
+  const lookup = encode
+    ? v => encodeURIComponent(getDynamicValue(ctx, qa, v))
+    : v => getDynamicValue(ctx, qa, v);
+
+  return mustache
+    .parse(s)
+    .map(t => (t[0] === "name" ? lookup(t[1]) : t[1]))
+    .join("");
+}
+
+function interpolate(ctx, qa, s) {
+  if (!s) return s;
+
+  return _splitUrls(s)
+    .map(([type, val]) => {
+      if (type === "url") return _interpolate(ctx, qa, val, true);
+      if (type === "text") return _interpolate(ctx, qa, val, false);
+    })
+    .join("");
+}
+
+function interpolateField(ctx, qa, field) {
+  const keys = ["title", "properties.description"];
+  const out = { ...field };
+  keys.forEach(k => _.set(out, k, interpolate(ctx, qa, _.get(out, k))));
+  return out;
+}
+
+function translateField(ctx, qa, field) {
+  return translator(addCustomType(interpolateField(ctx, qa, field)));
+}
+
+function getField({ form, user }, ref, index = false) {
   if (!form.fields.length) {
     throw new FieldError(`This form has no fields: ${form.id}`);
   }
@@ -13,44 +118,69 @@ function getField(form, ref) {
   const field = form.fields[idx];
 
   if (!field) {
-    throw new FieldError(`Could not find the requested field, ${ref},
-                          in our form: ${form.id}!`);
-  }
-  return field;
-}
-
-function setFirstRef(form, idx) {
-  return form.fields[idx].ref;
-}
-
-function getNext(form, ref) {
-  const idx = form.fields.map(({ ref }) => ref).indexOf(ref);
-  return form.fields[idx + 1];
-}
-
-function getNextField(form, qa, ref) {
-  const logic = form.logic && form.logic.find(logic => logic.ref === ref);
-
-  if (logic) {
-    const nxt = jump(form, qa, logic);
-    const field = getField(form, nxt);
-    return field;
-  }
-  return getNext(form, ref);
-}
-
-function getChoiceValue(form, ref, choice) {
-  const val = form.fields
-    .find(f => f.ref === ref)
-    .properties.choices.find(c => c.ref === choice).label;
-
-  if (!val) {
-    throw new TypeError(
-      `Could not find value for choice: ${choice} in question ${ref}`
+    throw new FieldError(
+      `Could not find the requested field, ${ref}, in our form: ${form.id}, for user id: ${user.id}!`
     );
   }
 
-  return val;
+  return index ? [idx, field] : field;
+}
+
+function _isLast(form, field) {
+  const idx = form.fields.findIndex(({ ref }) => ref === field);
+  return idx === form.fields.length - 1;
+}
+
+function _getNext(form, currentRef) {
+  // TODO: work out this ending logic....
+  // this should never be reached??
+  if (_isLast(form, currentRef)) {
+    return null;
+  }
+
+  const idx = form.fields.findIndex(({ ref }) => ref === currentRef);
+  return form.fields[idx + 1];
+}
+
+function getNextField(ctx, qa, currentRef) {
+  const { form } = ctx;
+
+  const logic = form.logic && form.logic.find(({ ref }) => ref === currentRef);
+
+  if (logic) {
+    const nxt = jump(ctx, qa, logic);
+    const field = getField(ctx, nxt);
+    return field;
+  }
+
+  return _getNext(form, currentRef);
+}
+
+function jump(ctx, qa, logic) {
+  // TODO: Handle case where logic fails and
+  // there is no default -- proper error and
+  // maybe work out a new state... "blocked?"
+
+  const { ref, actions } = logic;
+
+  for (let { condition, details } of actions) {
+    if (getCondition(ctx, qa, ref, condition)) {
+      return details.to.value;
+    }
+  }
+
+  // Default to next field if none found
+  return _getNext(ctx.form, ref).ref;
+}
+
+function getFieldValue(qa, ref) {
+  // last valid answer
+  const match = qa.filter(([q, __]) => q === ref).pop();
+
+  // return null if there are no matches,
+  // or if there are no answers,
+  const ans = match && match[1];
+  return ans ? ans : null;
 }
 
 const funs = {
@@ -75,58 +205,55 @@ function getCondition(ctx, qa, ref, { op, vars }) {
     throw new TypeError(`Cannot find operation: ${op}\nquestion: ${ref}`);
   }
 
+  // wrap in yaml safe-load to perform type-casting
+  // from form data (strings) to js native types
+  // i.e. boolean, null, etc.
   const fn = (a, b) => f(yaml.load(a), yaml.load(b));
 
-  return vars.map(v => getVar(ctx, qa, ref, vars, v)).reduce(fn);
+  // getChoiceValue needs to ref from the "field" type,
+  // which it is always paired with....
+
+  // vars should be length 2 unless and/or in which case
+  // can be length unlimited so we reduce through logic
+  return vars.map(v => getVar(ctx, qa, ref, v, vars)).reduce(fn);
 }
 
-function jump(ctx, qa, logic) {
-  const { ref, actions } = logic;
+function getChoiceValue({ form }, ref, choice) {
+  const val = form.fields
+    .find(f => f.ref === ref)
+    .properties.choices.find(c => c.ref === choice).label;
 
-  for (let { condition, details } of actions) {
-    if (getCondition(ctx, qa, ref, condition)) {
-      return details.to.value;
-    }
+  if (!val) {
+    throw new TypeError(
+      `Could not find value for choice: ${choice} in question ${ref}`
+    );
   }
 
-  // Default to next field if none found
-  return getNext(ctx, ref).ref;
+  return val;
 }
 
-function getFieldValue(qa, ref) {
-  // returns the last valid answer
-  const match = qa.filter(([q, __]) => q === ref).pop();
-
-  // return null if there are no matches,
-  // or if there are no answers,
-  // otherwise return match even if empty string
-
-  if (!match) {
-    return null;
-  } else {
-    return match[1];
-  }
-}
-
-function getVar(ctx, qa, ref, vars, v) {
-  // ops can be nested in a var
+function getVar(ctx, qa, ref, v, vars) {
   if (v.op) {
     return getCondition(ctx, qa, ref, v);
   }
 
   const { type, value } = v;
 
-  if (type === "constant") {
+  if (type == "constant") {
     return value;
   }
 
-  if (type === "choice") {
+  if (type == "choice") {
     const field = vars.find(v => v.type === "field").value;
     return getChoiceValue(ctx, field, value);
   }
 
-  if (type === "field") {
+  if (type == "field") {
     return getFieldValue(qa, value);
+  }
+
+  if (type == "hidden") {
+    return getFromMetadata(ctx, value);
   }
 }
 
@@ -143,60 +270,13 @@ function translateForm(form) {
   return f;
 }
 
-function filterFields(form) {
-  return form.fields.filter(field => field.type !== "thankyou_screen");
-}
-
-function _splitUrls(s) {
-  const re = RegExp(/https?:\/\/[^\s]+/gi);
-  const nonMatches = s.split(re).map(s => ["text", s]);
-  return nonMatches;
-}
-
-function getDynamicValue(qa, title) {
-  const regex = /:(.*)}}/;
-  const match = title.match(regex) ? title.match(regex) : false;
-  const ref = match ? match[1] : false;
-
-  const fieldValue = getFieldValue(qa, ref);
-
-  if (!match) {
-    return false;
-  }
-
-  if (!fieldValue) {
-    throw new TypeError(
-      `Trying to interpolate a non-existent field value: ${title}`
-    );
-  }
-
-  return fieldValue;
-}
-
-function _interpolate(qa, title) {
-  const titledParsed = Mustache.parse(title);
-
-  title = titledParsed
-    .map(t =>
-      t[0] === "name" ? t[1].replace(t[1], getDynamicValue(qa, title)) : t[1]
-    )
-    .join("");
-
-  return title;
-}
-
-function interpolateField(qa, field) {
-  const keys = ["title", "properties.description"];
-  const out = { ...field };
-
-  keys.forEach(k => _.set(out, k, _interpolate(qa, _.get(out, k))));
-
-  return out;
+function setFirstRef(form, idx) {
+  return form.fields[idx].ref;
 }
 
 function filterFieldTypes(form) {
   const types = form.fields.map(field => field.type);
-  const excludedTypes = ["thankyou_screen", "statement"];
+  const excludedTypes = ["thankyou_screen", "statement", "legal"];
 
   const filterArray = (types, excludedTypes) => {
     const filtered = types.filter(field => {
@@ -212,33 +292,32 @@ function isAQuestion(form, field) {
   return types.includes(field.type);
 }
 
+function getQuestionFields(form) {
+  return form.fields.filter(field => isAQuestion(form, field));
+}
+
 function setRequired() {
   const input = document.getElementById(`field-${field.id}}`);
   input.setAttribute("required", "required");
 }
 
-function getQuestionFields(form) {
-  return form.fields.filter(field => isAQuestion(form, field));
-}
-
 module.exports = {
-  getField,
-  setFirstRef,
-  getNextField,
-  getNext,
-  jump,
-  getFieldValue,
-  getChoiceValue,
-  getVar,
   getCondition,
-  translateForm,
-  filterFields,
+  getFieldValue,
+  jump,
+  getField,
+  getNextField,
+  translateField,
   interpolateField,
+  addCustomType,
+  getFromMetadata,
+  FieldError,
   _splitUrls,
-  _interpolate,
+  translateForm,
   getDynamicValue,
+  setFirstRef,
   filterFieldTypes,
   isAQuestion,
-  setRequired,
   getQuestionFields,
+  setRequired,
 };

--- a/websurvey/lib/typewheels/form.js
+++ b/websurvey/lib/typewheels/form.js
@@ -174,13 +174,18 @@ function jump(ctx, qa, logic) {
 }
 
 function getFieldValue(qa, ref) {
-  // last valid answer
+  // returns the last valid answer
   const match = qa.filter(([q, __]) => q === ref).pop();
 
   // return null if there are no matches,
   // or if there are no answers,
-  const ans = match && match[1];
-  return ans ? ans : null;
+  // otherwise return match even if empty string
+
+  if (!match) {
+    return null;
+  } else {
+    return match[1];
+  }
 }
 
 const funs = {

--- a/websurvey/lib/typewheels/form.js
+++ b/websurvey/lib/typewheels/form.js
@@ -255,6 +255,10 @@ function getVar(ctx, qa, ref, v, vars) {
   if (type == "hidden") {
     return getFromMetadata(ctx, value);
   }
+
+  if (type == "legal") {
+    console.log(type);
+  }
 }
 
 function translateForm(form) {
@@ -315,6 +319,8 @@ module.exports = {
   _splitUrls,
   translateForm,
   getDynamicValue,
+  getChoiceValue,
+  getVar,
   setFirstRef,
   filterFieldTypes,
   isAQuestion,

--- a/websurvey/lib/typewheels/form.test.js
+++ b/websurvey/lib/typewheels/form.test.js
@@ -593,6 +593,40 @@ describe("getCondition", () => {
 //   })
 // })
 
+describe("getChoiceValue", () => {
+  it("gets the value of the selected multiple choice field", () => {
+    const ref = "44659a5e-3640-460a-9614-bd3ae8311043";
+    const choice = "d3bc0725-4371-42ae-8bb4-0492eff445fb";
+    const value = f.getChoiceValue({ form }, ref, choice);
+    value.should.equal("Female");
+  });
+});
+
+describe("getVar", () => {
+  it("gets the field value depending on the var type", () => {
+    const ctx = form;
+    const qa = [["378caa71-fc4f-4041-8315-02b6f33616b9", 10]];
+    const ref = "44659a5e-3640-460a-9614-bd3ae8311043";
+    const vars = [
+      {
+        type: "field",
+        value: "378caa71-fc4f-4041-8315-02b6f33616b9",
+      },
+      {
+        type: "constant",
+        value: 15,
+      },
+    ];
+    const v = vars[0];
+    let value = f.getVar(ctx, qa, ref, v, vars);
+    value.should.equal(10);
+
+    const v2 = vars[1];
+    value = f.getVar(ctx, qa, ref, v2, vars);
+    value.should.equal(15);
+  });
+});
+
 describe("getDynamicValue", () => {
   const ctx = { log: [], user: {} };
   const qa = [["foo", "Continue"]];

--- a/websurvey/lib/typewheels/form.test.js
+++ b/websurvey/lib/typewheels/form.test.js
@@ -1,53 +1,36 @@
 const mocha = require("mocha");
 const chai = require("chai");
 const should = chai.should();
-const f = require("./form.js");
 const fs = require("fs");
-const sample = JSON.parse(fs.readFileSync("mocks/sample.json"));
-const form = f.translateForm(sample);
+const f = require("./form");
+const form = JSON.parse(fs.readFileSync("mocks/sample.json"));
 
-describe("getField", () => {
-  it("gets a field", () => {
-    const ctx = form;
-    const value = f.getField(ctx, "whats_your_name");
-    value.should.equal(form.fields[0]);
-  });
+const PAGE_ID = "1051551461692797";
+const USER_ID = "1800244896727776";
 
-  it("throws with a useful message when field not found in form", () => {
-    const ctx = form;
-    const fn = () => f.getField(ctx, "baz");
-    fn.should.throw(/baz/); // field
-    fn.should.throw(/DjlXLX2s/); // form
-  });
-});
+const referral = {
+  recipient: { id: PAGE_ID },
+  timestamp: 1542123799219,
+  sender: { id: USER_ID },
+  referral: {
+    ref: "form.FOO.foo.bar",
+    source: "SHORTLINK",
+    type: "OPEN_THREAD",
+  },
+};
 
-describe("setFirstRef", () => {
-  it("sets the first field ref", () => {
-    const ctx = form;
-    const value = f.setFirstRef(ctx, 0);
-    value.should.equal("whats_your_name");
-  });
-});
-
-describe("getNext", () => {
-  it("gets the next field object in the form", () => {
-    const field = form.fields[0];
-    const nextField = form.fields[1];
-    const value = f.getNext(form, field.ref);
-    value.should.equal(nextField);
-  });
-
-  it("gets the first thankyou screen after the last question", () => {
-    const value = f.getNext(form, "whats_your_age");
-    value.ref.should.equal("thankyou");
-  });
-});
+const text = {
+  sender: { id: USER_ID },
+  recipient: { id: PAGE_ID },
+  timestamp: 1542116363617,
+  message: { text: "foo" },
+};
 
 describe("getFieldValue", () => {
   it("gets the value of a text field", () => {
-    const qa = [["foo", "baz"]];
+    const qa = [["foo", "foo"]];
     const value = f.getFieldValue(qa, "foo");
-    value.should.equal("baz");
+    value.should.equal("foo");
   });
 
   // TODO: should this throw?
@@ -56,104 +39,307 @@ describe("getFieldValue", () => {
     const value = f.getFieldValue(qa, "foo");
     should.not.exist(value);
   });
+});
 
-  it("returns an empty string if the field exists but no answer is given", () => {
-    const qa = [["foo", ""]];
-    const value = f.getFieldValue(qa, "foo");
-    value.should.equal("");
+describe("getField", () => {
+  it("throws with a useful message when field not found in form", () => {
+    const ctx = { form, user: { name: "bar", id: "foo" } };
+    const fn = f.getField.bind(null, ctx, "baz");
+    fn.should.throw(/foo/); // user
+    fn.should.throw(/baz/); // field
+    fn.should.throw(/ODf5n7/); // form
+  });
+
+  it("gets the current field", () => {
+    const ctx = { form, user: { name: "bar", id: "foo" } };
+    const fn = f.getField(ctx, "378caa71-fc4f-4041-8315-02b6f33616b9", true);
+    fn.should.eql([
+      1,
+      {
+        id: "zGz4q4dPLUiB",
+        title: "Welcome!\nHow old are you?",
+        ref: "378caa71-fc4f-4041-8315-02b6f33616b9",
+        validations: { required: true },
+        type: "number",
+      },
+    ]);
   });
 });
 
-describe("getChoiceValue", () => {
-  it("gets the value of the selected multiple choice field", () => {
-    const ctx = form;
-    const ref = "how_is_your_day";
-    const choice = "67554758-9085-45b8-b658-46e5b9686361";
-
-    const value = f.getChoiceValue(ctx, ref, choice);
-    value.should.equal("Just OK...");
+describe("getNextField", () => {
+  it("gets the next field with any logic jumps", () => {
+    const ctx = { form };
+    const qa = [["378caa71-fc4f-4041-8315-02b6f33616b9", 21]];
+    const currentRef = "378caa71-fc4f-4041-8315-02b6f33616b9";
+    const fn = f.getNextField(ctx, qa, currentRef);
+    fn.should.eql({
+      id: "ePRsqS5Iwb9B",
+      title:
+        "We are going to ask you 12 questions about you and your everyday life. The survey will take just 5 minutes of your time. Please try to ansewer the questions carefully and truthfully.",
+      ref: "0ebfe765-0275-48b2-ad2d-3aacb5bc6755",
+      properties: {
+        hide_marks: false,
+        button_text: "Continue",
+      },
+      type: "statement",
+    });
   });
 });
 
-describe("getVar", () => {
-  it("gets the field value depending on the var type", () => {
-    const ctx = form;
-    const qa = [["how_is_your_day", "Terrific!"]];
-    const ref = "how_is_your_day";
-    const vars = [
-      {
-        type: "field",
-        value: "how_is_your_day",
-      },
-      {
-        type: "choice",
-        value: "c8c780a6-4210-4673-bf07-4130efde9151",
-      },
-    ];
-    const v = vars[0];
-    let value = f.getVar(ctx, qa, ref, vars, v);
-    value.should.equal("Terrific!");
+describe("getFromMetadata", () => {
+  it("works with unicode Facebook names", () => {
+    const name = "小飼弾";
+    const ctx = { user: { name } };
+    f.getFromMetadata(ctx, "name").should.equal(name);
+  });
 
-    const v2 = vars[1];
-    value = f.getVar(ctx, qa, ref, vars, v2);
-    value.should.equal("Terrific!");
+  it("works with false values", () => {
+    const ctx = { md: { event__foo_success: false } };
+    f.getFromMetadata(ctx, "event__foo_success").should.equal(false);
+  });
+
+  it("works with unicode Facebook names", () => {
+    const ctx = { md: { seed: 125 } };
+    f.getFromMetadata(ctx, "seed_5").should.equal(1);
+    f.getFromMetadata(ctx, "seed_1").should.equal(1);
+    f.getFromMetadata(ctx, "seed_4").should.equal(2);
+    f.getFromMetadata(ctx, "seed_3").should.equal(3);
+  });
+
+  it("works with unicode url values", () => {
+    const name = "小飼弾";
+
+    const md = {
+      form: "BAR",
+      foo: "小飼弾",
+      startTime: 1542123799219,
+      pageid: "1051551461692797",
+      seed: 2040794579,
+    };
+
+    const ctx = { md, user: { name: "Foo Bazzle" } };
+    f.getFromMetadata(ctx, "foo").should.equal(name);
+  });
+});
+
+describe("_splitUrls", () => {
+  it("groups by url", () => {
+    const split = f._splitUrls(
+      "hello https://foo.com?key={{bar}} baz http://hello.us"
+    );
+    split.should.deep.equal([
+      ["text", "hello "],
+      ["url", "https://foo.com?key={{bar}}"],
+      ["text", " baz "],
+      ["url", "http://hello.us"],
+    ]);
+  });
+
+  it("works with url at beginning", () => {
+    const split = f._splitUrls("https://foo.com?key={{bar}} baz");
+    split.should.deep.equal([
+      ["url", "https://foo.com?key={{bar}}"],
+      ["text", " baz"],
+    ]);
+  });
+
+  it("works with only url", () => {
+    const split = f._splitUrls("https://foo.com?key={{bar}}");
+    split.should.deep.equal([["url", "https://foo.com?key={{bar}}"]]);
+  });
+
+  it("works with text at end", () => {
+    const split = f._splitUrls("hello https://foo.com?key={{bar}} baz");
+    split.should.deep.equal([
+      ["text", "hello "],
+      ["url", "https://foo.com?key={{bar}}"],
+      ["text", " baz"],
+    ]);
+  });
+
+  it("works with no url", () => {
+    const split = f._splitUrls("hello baz");
+    split.should.deep.equal([["text", "hello baz"]]);
+  });
+});
+
+describe("interpolateField", () => {
+  it("works with hidden fields from user", () => {
+    const ctx = { log: [referral, text], user: { name: "Foo Bazzle" } };
+    const i = f.interpolateField(ctx, [], { title: "hello {{hidden:name}}" });
+    i.title.should.equal("hello Foo Bazzle");
+  });
+
+  it("works with hidden fields from referral", () => {
+    const name = "小飼弾";
+    const uni = encodeURIComponent(name);
+    const ref2 = {
+      ...referral,
+      referral: { ...referral.referral, ref: `form.BAR.foo.${uni}` },
+    };
+    const md = {
+      form: "BAR",
+      foo: "小飼弾",
+      startTime: 1542123799219,
+      pageid: "1051551461692797",
+      seed: 2040794579,
+    };
+    const ctx = { md, user: { name: "Foo Bazzle" } };
+    const i = f.interpolateField(ctx, [], { title: "hello {{hidden:foo}}" });
+    i.title.should.equal(`hello ${name}`);
+  });
+
+  it("works with previously answered fields", () => {
+    const ctx = { log: [], user: {} };
+    const i = f.interpolateField(ctx, [["foo", "Continue"]], {
+      title: "You chose: {{field:foo}}",
+    });
+    i.title.should.equal(`You chose: Continue`);
+  });
+
+  it("Throws if the field is unanswered", () => {
+    const ctx = { log: [], user: {} };
+    const fn = f.interpolateField.bind(null, ctx, [], {
+      title: "You chose: {{field:foo}}",
+    });
+    fn.should.throw();
+  });
+
+  it("works with description", () => {
+    const ctx = { log: [], user: { name: "Foo Bazzle" } };
+    const i = f.interpolateField(ctx, [], {
+      properties: { description: "name: {{hidden:name}}" },
+    });
+    i.properties.description.should.equal("name: Foo Bazzle");
+  });
+
+  it("encodes urls interpolation", () => {
+    const ctx = { log: [], user: { name: "Foo Bazzle" } };
+    const i = f.interpolateField(ctx, [], {
+      properties: {
+        description: "foo: bar\nurl: https://hello.com/?name={{hidden:name}}",
+      },
+    });
+    i.properties.description.should.equal(
+      "foo: bar\nurl: https://hello.com/?name=Foo%20Bazzle"
+    );
+  });
+
+  it("encodes urls interpolation inside text", () => {
+    const ctx = { log: [], user: { name: "Foo Bazzle" } };
+    const i = f.interpolateField(ctx, [], {
+      title: "Please visit: https://hello.com/?name={{hidden:name}}",
+    });
+    i.title.should.equal("Please visit: https://hello.com/?name=Foo%20Bazzle");
+  });
+});
+
+describe("addCustomType", () => {
+  it("changes the type from the yaml if exists", () => {
+    const field = {
+      type: "statement",
+      title: "foo",
+      ref: "foo",
+      properties: { description: "type: share" },
+    };
+    const out = f.addCustomType(field);
+    out.type.should.equal("share");
+  });
+
+  it("adds additional fields into the md property", () => {
+    const field = {
+      type: "statement",
+      title: "foo",
+      ref: "foo",
+      properties: { description: "type: share\nurl: foo" },
+    };
+    const out = f.addCustomType(field);
+    out.md.url.should.equal("foo");
+  });
+
+  it("doesnt change it if no yaml", () => {
+    const field = {
+      type: "statement",
+      title: "foo",
+      ref: "foo",
+      properties: { description: "#notyaml&foo=bar" },
+    };
+    const out = f.addCustomType(field);
+    out.type.should.equal("statement");
+  });
+
+  it("doesnt change the type with a different yaml", () => {
+    const field = {
+      type: "statement",
+      title: "foo",
+      ref: "foo",
+      properties: { description: "foo: bar" },
+    };
+    const out = f.addCustomType(field);
+    out.type.should.equal("statement");
+  });
+
+  it("doesnt change anything with no description", () => {
+    const field = {
+      type: "multiple_choice",
+      title: "foo",
+      ref: "foo",
+      properties: { choices: [{ label: "qux" }, { label: "quux" }] },
+    };
+    const out = f.addCustomType(field);
+    out.type.should.equal("multiple_choice");
+  });
+});
+
+describe("jump", () => {
+  it("makes jump when required and not when not", () => {
+    const qaBad = [["378caa71-fc4f-4041-8315-02b6f33616b9", "10"]];
+    const qaGood = [["378caa71-fc4f-4041-8315-02b6f33616b9", "18"]];
+
+    const yes = f.jump({ form }, qaGood, form.logic[0]);
+    yes.should.equal("0ebfe765-0275-48b2-ad2d-3aacb5bc6755");
+
+    const no = f.jump({ form }, qaBad, form.logic[0]);
+    no.should.equal("3edb7fcc-748c-461c-bacd-593c043c5518");
+  });
+
+  // TODO: should this throw??????
+  it("doesnt make jump if required field doesnt exist", () => {
+    const no = f.jump({ form }, [], form.logic[0]);
+    no.should.equal("3edb7fcc-748c-461c-bacd-593c043c5518");
+  });
+
+  // TODO: this should be checked at form load time
+  it("it defaults to the next field if it cannot fulfil logic jump for any reason", () => {
+    const logic = {
+      type: "field",
+      actions: [
+        {
+          action: "jump",
+          details: { to: { type: "field", value: "foo" } },
+          condition: {
+            op: "is",
+            vars: [
+              { type: "field", value: "baz" },
+              { type: "constant", value: "15" },
+            ],
+          },
+        },
+      ],
+    };
+
+    let fallback = f.jump({ form }, [["baz", "14"]], logic);
+    fallback.should.equal(form.fields[0].ref);
+
+    fallback = f.jump({ form }, [], logic);
+    fallback.should.equal(form.fields[0].ref);
   });
 });
 
 describe("getCondition", () => {
-  const cond = {
-    op: "always",
-    vars: [
-      { type: "field", value: "baz" },
-      { type: "constant", value: 10 },
-    ],
-  };
-
   it("works with always true", () => {
-    f.getCondition({ form }, [], "", cond).should.be.true;
-  });
-
-  it("works with string equals", () => {
-    const cond = {
-      op: "equal",
-      vars: [
-        { type: "field", value: "whats_your_name" },
-        { type: "constant", value: "baz" },
-      ],
-    };
-
-    const ref = "whats_your_name";
-
-    const qaGood = [["whats_your_name", "baz"]];
-    const qaBad = [["whats_your_name", ""]];
-
-    f.getCondition({ form }, qaGood, ref, cond).should.be.true;
-    f.getCondition({ form }, qaGood, ref, { ...cond, op: "is" }).should.be.true;
-    f.getCondition({ form }, qaBad, ref, cond).should.be.false;
-    f.getCondition({ form }, qaBad, ref, { ...cond, op: "is_not" }).should.be
-      .true;
-  });
-
-  it("works with string not equals", () => {
-    const cond = {
-      op: "not_equal",
-      vars: [
-        { type: "field", value: "whats_your_name" },
-        { type: "constant", value: "" },
-      ],
-    };
-
-    const ref = "whats_your_name";
-
-    const qaGood = [["whats_your_name", "baz"]];
-    const qaBad = [["whats_your_name", ""]];
-
-    f.getCondition({ form }, qaGood, ref, cond).should.be.true;
-    f.getCondition({ form }, qaGood, ref, { ...cond, op: "is" }).should.be
-      .false;
-    f.getCondition({ form }, qaBad, ref, cond).should.be.false;
-    f.getCondition({ form }, qaBad, ref, { ...cond, op: "is_not" }).should.be
-      .false;
+    const con = form.logic[2].actions[0].condition;
+    f.getCondition({ form }, [], "", con).should.be.true;
   });
 
   it("works with number equals and not equals is and is not - casts types from strings", () => {
@@ -174,18 +360,25 @@ describe("getCondition", () => {
       .false;
   });
 
-  it("works with number not equals - type casting!", () => {
+  it("works with boolean strings in form and true boolean in metadata", () => {
     const cond = {
       op: "is",
       vars: [
-        { type: "field", value: "baz" },
-        { type: "constant", value: 10 },
+        { type: "hidden", value: "baz" },
+        { type: "constant", value: "true" },
       ],
     };
 
-    const qa = [["baz", "11"]];
+    const qa = [];
+    const md = { baz: true };
 
-    f.getCondition({ form }, qa, "", cond).should.be.false;
+    f.getCondition({ form, md }, qa, "", cond).should.be.true;
+    f.getCondition({ form, md }, qa, "", { ...cond, op: "equal" }).should.be
+      .true;
+    f.getCondition({ form, md }, qa, "", { ...cond, op: "is_not" }).should.be
+      .false;
+    f.getCondition({ form, md }, qa, "", { ...cond, op: "not_equal" }).should.be
+      .false;
   });
 
   it("works with lower_equal_than operator on numbers", () => {
@@ -251,130 +444,197 @@ describe("getCondition", () => {
     f.getCondition({ form }, qa2, "", cond).should.be.false;
     f.getCondition({ form }, qa2, "", { ...cond, op: "or" }).should.be.true;
   });
-});
 
-describe("jump", () => {
-  it("makes jump when required and makes no jump when not", () => {
-    const logic = form.logic[0];
-
-    const qaGood = [["how_is_your_day", "Terrific!"]];
-    const qaBad = [["how_is_your_day", "Just OK..."]];
-
-    const yes = f.jump(form, qaGood, logic);
-    yes.should.equal("awesome");
-
-    const no = f.jump(form, qaBad, logic);
-    no.should.equal("oh_no");
-  });
-});
-
-describe("getNextField", () => {
-  it("gets the next field in the form taking into account any logic jumps", () => {
-    const ref = "how_is_your_day";
-    const qaGood = [["how_is_your_day", "Terrific!"]];
-    const qaBad = [["how_is_your_day", "Just OK.."]];
-
-    const yes = f.getNextField(form, qaGood, ref);
-    yes.ref.should.equal("awesome");
-
-    const no = f.getNextField(form, qaBad, ref);
-    no.ref.should.equal("oh_no");
-  });
-});
-
-describe("translateForm", () => {
-  it("forms one array of fields and thankyou screens", () => {
-    const fields = sample.fields.length;
-    const thankyouScreens = sample.thankyou_screens.length;
-
-    const val = f.translateForm(sample).fields;
-    val.length.should.equal(fields + thankyouScreens);
-  });
-});
-
-describe("_splitUrls", () => {
-  it("works with no url", () => {
-    const split = f._splitUrls("hello baz");
-    split.should.deep.equal([["text", "hello baz"]]);
-  });
-});
-
-describe("getDynamicValue", () => {
-  it("returns the field value of a previously answered question", () => {
-    const qa = [["whats_your_name", "baz"]];
-    const title =
-      "Nice to meet you, {{field:whats_your_name}}, how is your day going?";
-    const i = f.getDynamicValue(qa, title);
-    i.should.equal("baz");
-  });
-
-  it("returns false if there is no dynamic value to interpolate", () => {
-    const qa = [["whats_your_name", "baz"]];
-    const title = "How old are you?";
-    const i = f.getDynamicValue(qa, title);
-    i.should.equal(false);
-  });
-
-  it("throws if an invalid field value is found", () => {
-    const qa = [["whats_your_name", ""]];
-    const title =
-      "Nice to meet you, {{field:whats_your_name}}, how is your day going?";
-    const fn = () => f.getDynamicValue(qa, title);
-    fn.should.throw(
-      /Nice to meet you, {{field:whats_your_name}}, how is your day going/
-    ); // title
-  });
-});
-
-describe("_interpolate", () => {
-  it("interpolates a field with a dynamic value", () => {
-    const qa = [["whats_your_name", "baz"]];
-    const title =
-      "Nice to meet you, {{field:whats_your_name}}, how is your day going?";
-    const i = f._interpolate(qa, title);
-    i.should.equal("Nice to meet you, baz, how is your day going?");
-  });
-});
-
-describe("interpolateField", () => {
-  const qa = [["whats_your_name", "baz"]];
-  const field = {
-    type: "multiple_choice",
-    title:
-      "Nice to meet you, {{field:whats_your_name}}, how is your day going?",
-    ref: "how_is_your_day",
-  };
-
-  it("works with previously answered fields", () => {
-    const i = f.interpolateField(qa, field);
-    i.title.should.equal("Nice to meet you, baz, how is your day going?");
-  });
-
-  it("works when there is no dynamic value", () => {
-    const qa = [["whats_your_name", "baz"]];
-    const field = {
-      type: "multiple_choice",
-      title: "Nice to meet you, how is your day going?",
-      ref: "how_is_your_day",
+  it("works with triple operators", () => {
+    const cond = {
+      op: "or",
+      vars: [
+        {
+          op: "equal",
+          vars: [
+            {
+              type: "hidden",
+              value: "seed_16",
+            },
+            {
+              type: "constant",
+              value: "9",
+            },
+          ],
+        },
+        {
+          op: "equal",
+          vars: [
+            {
+              type: "hidden",
+              value: "seed_16",
+            },
+            {
+              type: "constant",
+              value: "10",
+            },
+          ],
+        },
+        {
+          op: "equal",
+          vars: [
+            {
+              type: "hidden",
+              value: "seed_16",
+            },
+            {
+              type: "constant",
+              value: "11",
+            },
+          ],
+        },
+        {
+          op: "equal",
+          vars: [
+            {
+              type: "hidden",
+              value: "seed_16",
+            },
+            {
+              type: "constant",
+              value: "12",
+            },
+          ],
+        },
+      ],
     };
 
-    const i = f.interpolateField(qa, field);
-    i.title.should.equal("Nice to meet you, how is your day going?");
+    const qa = [];
+
+    f.getCondition({ form, md: { seed: 0 } }, qa, "", cond).should.be.false;
+    f.getCondition({ form, md: { seed: 7 } }, qa, "", cond).should.be.false;
+    f.getCondition({ form, md: { seed: 8 } }, qa, "", cond).should.be.true;
+    f.getCondition({ form, md: { seed: 1870657866 } }, qa, "", cond).should.be
+      .true;
+  });
+
+  it("works with a choice on a previous field", () => {
+    const cond = {
+      op: "is",
+      vars: [
+        {
+          type: "field",
+          value: "44659a5e-3640-460a-9614-bd3ae8311043",
+        },
+        {
+          type: "choice",
+          value: "d3bc0725-4371-42ae-8bb4-0492eff445fb",
+        },
+      ],
+    };
+
+    const qa = [["44659a5e-3640-460a-9614-bd3ae8311043", "Female"]];
+    f.getCondition({ form }, qa, "", cond).should.be.true;
+  });
+
+  it("works with a hidden field", () => {
+    const cond = {
+      op: "is",
+      vars: [
+        {
+          type: "hidden",
+          value: "bar",
+        },
+        {
+          type: "constant",
+          value: "foo",
+        },
+      ],
+    };
+
+    f.getCondition({ form, md: { bar: "foo" } }, [], "", cond).should.be.true;
+  });
+
+  it("works with the hidden random seed field", () => {
+    const cond = {
+      op: "equal",
+      vars: [
+        {
+          type: "hidden",
+          value: "seed_5",
+        },
+        {
+          type: "constant",
+          value: "1",
+        },
+      ],
+    };
+
+    f.getCondition({ form, md: { seed: 10 } }, [], "", cond).should.be.true;
+    f.getCondition({ form, md: { seed: 11 } }, [], "", cond).should.be.false;
+  });
+
+  it("works with number not equals - type casting!", () => {
+    const cond = {
+      op: "is",
+      vars: [
+        { type: "field", value: "baz" },
+        { type: "constant", value: 10 },
+      ],
+    };
+
+    const qa = [["baz", "11"]];
+
+    f.getCondition({ form }, qa, "", cond).should.be.false;
+  });
+});
+
+// TODO: move this to VALIDATORS module!
+// describe('formValidator', () => {
+//   it('deals with empty form with a helpful error', () => {
+//     const badform = {...form, fields: []}
+//     const fn = f.formValidator.bind(null, badform)
+//     fn.should.throw(TypeError)
+//   })
+// })
+
+describe("getDynamicValue", () => {
+  const ctx = { log: [], user: {} };
+  const qa = [["foo", "Continue"]];
+  const v = "field:foo";
+  const i = f.getDynamicValue(ctx, qa, v);
+  i.should.equal(`Continue`);
+});
+
+describe("setFirstRef", () => {
+  it("sets the first field ref", () => {
+    const ctx = form;
+    const value = f.setFirstRef(ctx, 0);
+    value.should.equal("4cc5c31b-6d23-4d50-8536-7abf1cdf0782");
   });
 });
 
 describe("filterFieldTypes", () => {
   it("returns a filtered array of question types only", () => {
     const value = f.filterFieldTypes(form);
-    value.should.eql(["short_text", "multiple_choice", "number"]);
+    value.should.eql([
+      "number",
+      "multiple_choice",
+      "multiple_choice",
+      "multiple_choice",
+      "multiple_choice",
+      "opinion_scale",
+      "multiple_choice",
+      "multiple_choice",
+      "multiple_choice",
+      "multiple_choice",
+      "rating",
+      "multiple_choice",
+      "rating",
+    ]);
   });
 });
 
 describe("isAQuestion", () => {
   it("returns true if a field is a question", () => {
     const field = {
-      ref: "whats_your_name",
-      type: "short_text",
+      ref: "378caa71-fc4f-4041-8315-02b6f33616b9",
+      type: "number",
     };
     const value = f.isAQuestion(form, field);
     value.should.be.true;
@@ -393,6 +653,6 @@ describe("isAQuestion", () => {
 describe("getQuestionFields", () => {
   it("returns only the fields that are questions", () => {
     const value = f.getQuestionFields(form);
-    value.length.should.equal(3);
+    value.length.should.equal(13);
   });
 });

--- a/websurvey/lib/typewheels/form.test.js
+++ b/websurvey/lib/typewheels/form.test.js
@@ -647,6 +647,7 @@ describe("filterFieldTypes", () => {
   it("returns a filtered array of question types only", () => {
     const value = f.filterFieldTypes(form);
     value.should.eql([
+      "multiple_choice",
       "number",
       "multiple_choice",
       "multiple_choice",
@@ -687,6 +688,6 @@ describe("isAQuestion", () => {
 describe("getQuestionFields", () => {
   it("returns only the fields that are questions", () => {
     const value = f.getQuestionFields(form);
-    value.length.should.equal(13);
+    value.length.should.equal(14);
   });
 });

--- a/websurvey/lib/typewheels/responseStore.js
+++ b/websurvey/lib/typewheels/responseStore.js
@@ -32,14 +32,14 @@ class ResponseStore {
     }
   }
 
-  interpolate(field, qa) {
+  interpolate(ctx, field, qa) {
     try {
-      f.interpolateField(qa, field);
+      f.interpolateField(ctx, qa, field);
     } catch (e) {
       alert(e.message);
     }
 
-    return f.interpolateField(qa, field);
+    return f.interpolateField(ctx, qa, field);
   }
 }
 

--- a/websurvey/lib/typewheels/responseStore.js
+++ b/websurvey/lib/typewheels/responseStore.js
@@ -20,12 +20,12 @@ class ResponseStore {
     const isValid = v.validateFieldValue(field, fieldValue);
     if (isValid) {
       return {
-        ref: f.getNextField(form, qa, ref, field).ref,
+        ref: f.getNextField({ form }, qa, ref, field).ref,
         action: "navigate",
       };
     } else {
       return {
-        ref: f.getField(form, ref).ref,
+        ref: f.getField({ form }, ref).ref,
         action: "error",
         error: v.validator(field)(fieldValue),
       };

--- a/websurvey/lib/typewheels/responseStore.test.js
+++ b/websurvey/lib/typewheels/responseStore.test.js
@@ -69,7 +69,29 @@ describe("next", () => {
     };
 
     const fieldValue = 10;
-    const qa = [["378caa71-fc4f-4041-8315-02b6f33616b9", 10]];
+    const qa = [["378caa71-fc4f-4041-8315-02b6f33616b9", 20]];
+    const ref = field.ref;
+    const res = responseStore.next(form, qa, ref, field, fieldValue);
+
+    res.action.should.equal("navigate");
+  });
+
+  it("instructs the form to go to the next field if an answer evaluates to valid", () => {
+    const responseStore = new r.ResponseStore();
+
+    const field = {
+      type: "legal",
+      title:
+        "Welcome! 😀\nWe are a team of researchers conducting a study about life and opinions of young people in India. In the coming weeks, we will share with you some nice and short videoclips that you can watch for free. We will also ask you some questions about them. If you agree to take part to this study and you answer our questions, then you will have the chance of winning up to *10 Samsung Galaxy s8!*\n\nYour answers will always remain confidential.\n\nBy clicking the Accept botton, you confirm you have read and accept the _General Terms and Conditions_ contained in the Consent Form available at the link below.\n",
+      ref: "4cc5c31b-6d23-4d50-8536-7abf1cdf0782",
+    };
+    const fieldValue = "4cc5c31b-6d23-4d50-8536-7abf1cdf0782";
+    const qa = [
+      [
+        "4cc5c31b-6d23-4d50-8536-7abf1cdf0782",
+        "4cc5c31b-6d23-4d50-8536-7abf1cdf0782",
+      ],
+    ];
     const ref = field.ref;
     const res = responseStore.next(form, qa, ref, field, fieldValue);
 

--- a/websurvey/lib/typewheels/responseStore.test.js
+++ b/websurvey/lib/typewheels/responseStore.test.js
@@ -46,14 +46,14 @@ describe("next", () => {
     const responseStore = new r.ResponseStore();
 
     const field = {
-      type: "short_text",
-      title: "whats_your_name",
-      ref: "whats_your_name",
+      type: "number",
+      title: "Welcome!\nHow old are you?",
+      ref: "378caa71-fc4f-4041-8315-02b6f33616b9",
     };
 
-    const fieldValue = 10;
-    const qa = [["whats_your_name", 10]];
-    const ref = "whats_your_name";
+    const fieldValue = "baz";
+    const qa = [["378caa71-fc4f-4041-8315-02b6f33616b9", "baz"]];
+    const ref = "378caa71-fc4f-4041-8315-02b6f33616b9";
     const value = responseStore.next(form, qa, ref, field, fieldValue);
 
     value.action.should.equal("error");
@@ -63,13 +63,13 @@ describe("next", () => {
     const responseStore = new r.ResponseStore();
 
     const field = {
-      type: "short_text",
-      title: "whats_your_name",
-      ref: "whats_your_name",
+      type: "number",
+      title: "Welcome!\nHow old are you?",
+      ref: "378caa71-fc4f-4041-8315-02b6f33616b9",
     };
 
-    const fieldValue = "foo";
-    const qa = [["whats_your_name", "foo"]];
+    const fieldValue = 10;
+    const qa = [["378caa71-fc4f-4041-8315-02b6f33616b9", 10]];
     const ref = field.ref;
     const res = responseStore.next(form, qa, ref, field, fieldValue);
 

--- a/websurvey/lib/typewheels/translate-fields.js
+++ b/websurvey/lib/typewheels/translate-fields.js
@@ -1,0 +1,345 @@
+const translateShortText = data => {
+  return { text: data.title };
+};
+
+//welcome_screen
+const translateWelcomeScreen = (data, ref) => {
+  const text = data.properties.button_text;
+  return makeMultipleChoice(data.title, [{ label: text }], ref);
+};
+
+const translateLongText = translateShortText;
+const translateNumber = translateShortText;
+const translateDate = translateShortText;
+
+const translateStatement = data => {
+  const response = translateShortText(data);
+  response.metadata = { type: "statement" };
+  return response;
+};
+
+const translateThankYouScreen = data => {
+  const title = data.title.split("\n")[0];
+  const response = translateShortText({ title });
+  response.metadata = { type: "thankyou_screen" };
+  return response;
+};
+
+const makeMultipleChoice = (text, choices, ref) => {
+  // let's try multiple elements??
+  const response = { text };
+  response.quick_replies = choices.map(choice => {
+    const [title, value] = Array.isArray(choice)
+      ? choice
+      : [choice.label, choice.label];
+    return {
+      content_type: "text",
+      title: title,
+      payload: JSON.stringify({ value, ref }),
+    };
+  });
+
+  return response;
+};
+
+const _makeSimpleChoice = (text, choices, ref) => {
+  const response = {};
+  const buttons = choices.map(choice => {
+    // use choice.id for multiple choice??
+    const [title, value] = Array.isArray(choice)
+      ? choice
+      : [choice.label, choice.label];
+
+    return {
+      type: "postback",
+      title: title,
+      payload: JSON.stringify({ value: value, ref: ref }),
+    };
+  });
+  response.attachment = {
+    type: "template",
+    payload: {
+      template_type: "button",
+      text: text,
+      buttons,
+    },
+  };
+  return response;
+};
+
+//multiple_choice
+const translateMultipleChoice = (data, ref) => {
+  return makeMultipleChoice(data.title, data.properties.choices, ref);
+};
+
+const translateDropDown = translateMultipleChoice;
+
+//yes_no to quick reply
+const translateYesNo = (data, ref) => {
+  return _makeSimpleChoice(
+    data.title,
+    [
+      ["Yes", true],
+      ["No", false],
+    ],
+    ref
+  );
+};
+
+const translateLegal = (data, ref) => {
+  return _makeSimpleChoice(
+    data.title,
+    [
+      ["I Accept", true],
+      ["I don't Accept", false],
+    ],
+    ref
+  );
+};
+
+//email to quick reply (fb has qr button for sending email assoc with account)
+const translateEmail = data => {
+  const response = translateShortText(data);
+  response.quick_replies = [
+    {
+      content_type: "user_email",
+    },
+  ];
+  return response;
+};
+
+const translatePhone = data => {
+  const response = translateShortText(data);
+  response.quick_replies = [
+    {
+      content_type: "user_phone_number",
+    },
+  ];
+  return response;
+};
+
+const translateRatings = (data, ref) => {
+  const start = data.properties.start_at_one === false ? 0 : 1;
+  const steps = data.properties.steps;
+
+  const choices = new Array(steps)
+    .fill("*")
+    .map((e, i) => ({ label: `${i + start}` }));
+
+  return makeMultipleChoice(data.title, choices, ref);
+};
+
+//opinion scale to quick reply
+const translateOpinionScale = translateRatings;
+
+//transform to carousel of generic templates
+const translatePictureChoice = data => {
+  const response = {};
+  const elements = data.properties.choices.map(choice => {
+    const buttons = [
+      {
+        type: "postback",
+        title: `select ${choice.label}`,
+        payload: choice.label,
+      },
+    ];
+    return {
+      title: data.title,
+      image_url: choice.attachment.href,
+      buttons,
+    };
+  });
+  response.attachment = {
+    type: "template",
+    payload: {
+      template_type: "generic",
+      elements,
+    },
+  };
+  return response;
+};
+
+function _shareButton(shareText, buttonText, url) {
+  return {
+    type: "element_share",
+    share_contents: {
+      attachment: {
+        type: "template",
+        payload: {
+          template_type: "generic",
+          elements: [
+            {
+              title: shareText || "Take this survey",
+              // "subtitle": "<TEMPLATE_SUBTITLE>",
+              // "image_url": "<IMAGE_URL_TO_DISPLAY>",
+              default_action: {
+                type: "web_url",
+                url: url,
+              },
+              buttons: [
+                {
+                  type: "web_url",
+                  url: url,
+                  title: buttonText || "Start",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+const translateShare = data => {
+  const { url, shareText, buttonText } = data.md;
+
+  const response = {
+    attachment: {
+      type: "template",
+      payload: {
+        template_type: "button",
+        text: data.title,
+        buttons: [_shareButton(shareText, buttonText, url)],
+      },
+    },
+  };
+
+  return response;
+};
+
+const translateWait = translateShortText;
+const translateStitch = translateShortText;
+
+const translateNotify = (data, ref) => {
+  const response = {
+    attachment: {
+      type: "template",
+      payload: {
+        template_type: "one_time_notif_req",
+        title: data.title,
+        payload: JSON.stringify({ ref }),
+      },
+    },
+  };
+
+  return response;
+};
+
+const makeUrl = url => {
+  if (typeof url === "string") {
+    return url;
+  }
+
+  const { base, protocol = "https", params = {} } = url;
+
+  if (!base) {
+    throw new Error(`Invalid URL object for creating a URL: ${url}`);
+  }
+
+  const p = new URLSearchParams(params);
+  const b = new URL(`${protocol}://${base}`);
+  b.search = p.toString();
+  return b.href;
+};
+
+const translateWebview = data => {
+  const { url, buttonText, extensions } = data.md;
+
+  const response = {
+    attachment: {
+      type: "template",
+      payload: {
+        template_type: "button",
+        text: data.title,
+        buttons: [
+          {
+            type: "web_url",
+            url: makeUrl(url),
+            title: buttonText || "View website",
+            webview_height_ratio: "full",
+            // default extensions to true
+            messenger_extensions: extensions === undefined ? true : extensions,
+          },
+        ],
+      },
+    },
+  };
+  return response;
+};
+
+const translateAttachment = data => {
+  const { attachment } = data.md;
+  const { type, url } = attachment;
+
+  const response = {
+    attachment: {
+      type: type,
+      payload: {
+        url: url,
+        is_reusable: true,
+      },
+    },
+  };
+  return response;
+};
+
+const lookup = {
+  short_text: translateShortText,
+  multiple_choice: translateMultipleChoice,
+  email: translateEmail,
+  phone_number: translatePhone,
+  picture_choice: translatePictureChoice,
+  long_text: translateLongText,
+  welcome_screen: translateWelcomeScreen,
+  thankyou_screen: translateThankYouScreen,
+  legal: translateLegal,
+  yes_no: translateYesNo,
+  number: translateNumber,
+  statement: translateStatement,
+  opinion_scale: translateOpinionScale,
+  rating: translateRatings,
+  share: translateShare,
+  webview: translateWebview,
+  wait: translateWait,
+  stitch: translateStitch,
+  notify: translateNotify,
+  attachment: translateAttachment,
+};
+
+function translator(question) {
+  const fn = lookup[question.type];
+  if (!fn) {
+    throw new TypeError(
+      `There is no translator for the question of type ${question.type}`
+    );
+  }
+  const response = fn(question, question.ref);
+
+  response.metadata = JSON.stringify({
+    ...response.metadata,
+    ...question.md,
+    ref: question.ref,
+  });
+  return response;
+}
+
+module.exports = {
+  translator,
+  translateWelcomeScreen,
+  translateThankYouScreen,
+  translateShortText,
+  translateLongText,
+  translateNumber,
+  translateStatement,
+  translateYesNo,
+  translateMultipleChoice,
+  translateDropDown,
+  translateEmail,
+  translateOpinionScale,
+  translateRatings,
+  translatePictureChoice,
+  translateDate,
+  translateLegal,
+  makeUrl,
+};

--- a/websurvey/lib/typewheels/validator.js
+++ b/websurvey/lib/typewheels/validator.js
@@ -72,6 +72,7 @@ const lookup = {
   multiple_choice: validateString,
   statement: validateStatement,
   thankyou_screen: validateStatement,
+  legal: validateStatement,
 };
 
 function validator(field, messages = {}) {

--- a/websurvey/lib/typewheels/validator.js
+++ b/websurvey/lib/typewheels/validator.js
@@ -1,3 +1,5 @@
+const { translator } = require("./translate-fields");
+
 const defaultMessages = {
   "label.error.mustEnter":
     "Sorry, that answer is not valid. Please try to answer the question again.",
@@ -57,6 +59,23 @@ function validateStatement(field, messages) {
   });
 }
 
+function _validateMC(r, titles, messages) {
+  // Messenger will return us numbers in JSON,
+  // but typeform mostly uses strings, except for booleans.
+  // So we cast everything to strings, to compare with QR's
+  return {
+    message: messages["label.error.mustSelect"],
+    valid: titles.map(t => "" + t).indexOf("" + r) !== -1,
+  };
+}
+
+// function validateQR(field, messages) {
+//   const q = translator(field);
+//   const titles = q.quick_replies.map(r => r.title);
+
+//   return r => _validateMC(r, titles, messages);
+// }
+
 function validateFieldValue(field, fieldValue) {
   const res = validator(field)(fieldValue);
 
@@ -73,6 +92,8 @@ const lookup = {
   statement: validateStatement,
   thankyou_screen: validateStatement,
   legal: validateStatement,
+  rating: validateNumber,
+  opinion_scale: validateNumber,
 };
 
 function validator(field, messages = {}) {

--- a/websurvey/mocks/sample.json
+++ b/websurvey/mocks/sample.json
@@ -1,88 +1,79 @@
 {
-  "id": "DjlXLX2s",
-  "type": "quiz",
-  "title": "Virtual Lab Survey",
-  "workspace": {
-    "href": "https://api.typeform.com/workspaces/Ghm6de"
-  },
+  "id": "ODf5n7",
+  "title": "Messenger Ad 0.1",
   "theme": {
-    "href": "https://api.typeform.com/themes/qHWOQ7"
+    "href": "https://api.typeform.com/themes/6lPNE6"
+  },
+  "workspace": {
+    "href": "https://api.typeform.com/workspaces/sZGZdB"
   },
   "settings": {
-    "language": "en",
-    "progress_bar": "proportion",
-    "meta": {
-      "allow_indexing": false
-    },
-    "hide_navigation": false,
     "is_public": true,
     "is_trial": false,
+    "language": "en",
+    "progress_bar": "percentage",
     "show_progress_bar": true,
     "show_typeform_branding": true,
-    "are_uploads_public": false,
-    "show_time_to_complete": true,
-    "pro_subdomain_enabled": false,
-    "capabilities": {
-      "e2e_encryption": {
-        "enabled": false,
-        "modifiable": false
-      }
+    "meta": {
+      "allow_indexing": false
     }
   },
   "thankyou_screens": [
     {
-      "id": "oBB8D27w4zil",
-      "ref": "thankyou",
-      "title": "Thanks for completing our survey! ",
-      "properties": {
-        "show_button": true,
-        "share_icons": true,
-        "button_mode": "reload",
-        "button_text": "reload"
-      }
-    },
-    {
-      "id": "DefaultTyScreen",
       "ref": "default_tys",
-      "title": "Thanks for completing this typeform\nNow *create your own* — it's free, easy, & beautiful",
+      "title": "Done! Your information was sent perfectly.",
       "properties": {
-        "show_button": true,
-        "share_icons": false,
-        "button_mode": "default_redirect",
-        "button_text": "Create a *typeform*"
-      },
-      "attachment": {
-        "type": "image",
-        "href": "https://images.typeform.com/images/2dpnUBBkz2VN"
+        "show_button": false,
+        "share_icons": false
       }
     }
   ],
   "fields": [
     {
-      "id": "5Qw3haKmUlKG",
-      "title": "Hello, what's your name?",
-      "ref": "whats_your_name",
-      "properties": {},
+      "id": "yKZz36sma0q5",
+      "title": "Welcome! 😀\nWe are a team of researchers conducting a study about life and opinions of young people in India. In the coming weeks, we will share with you some nice and short videoclips that you can watch for free. We will also ask you some questions about them. If you agree to take part to this study and you answer our questions, then you will have the chance of winning up to *10 Samsung Galaxy s8!*\n\nYour answers will always remain confidential.\n\nBy clicking the Accept botton, you confirm you have read and accept the _General Terms and Conditions_ contained in the Consent Form available at the link below.\n",
+      "ref": "4cc5c31b-6d23-4d50-8536-7abf1cdf0782",
+      "properties": {
+        "description": "https://drive.google.com/file/d/1Eovlbbysgdip6cwOfgl6r-r6nkoR1wyT/view?usp=sharing"
+      },
       "validations": {
         "required": true
       },
-      "type": "short_text",
-      "attachment": {
-        "type": "image",
-        "href": "https://images.typeform.com/images/WMALzu59xbXQ"
-      },
-      "layout": {
-        "type": "split",
-        "attachment": {
-          "type": "image",
-          "href": "https://images.typeform.com/images/WMALzu59xbXQ"
-        }
-      }
+      "type": "legal"
     },
     {
-      "id": "0gQBt2ecOSRK",
-      "title": "Nice to meet you, {{field:whats_your_name}}, how is your day going?",
-      "ref": "how_is_your_day",
+      "id": "zGz4q4dPLUiB",
+      "title": "Welcome!\nHow old are you?",
+      "ref": "378caa71-fc4f-4041-8315-02b6f33616b9",
+      "validations": {
+        "required": true
+      },
+      "type": "number"
+    },
+    {
+      "id": "RO4GRuyGIIMP",
+      "title": "We are sorry, but you are either too young or too old to take part to this game.",
+      "ref": "3edb7fcc-748c-461c-bacd-593c043c5518",
+      "properties": {
+        "hide_marks": false,
+        "button_text": "End"
+      },
+      "type": "statement"
+    },
+    {
+      "id": "ePRsqS5Iwb9B",
+      "title": "We are going to ask you 12 questions about you and your everyday life. The survey will take just 5 minutes of your time. Please try to ansewer the questions carefully and truthfully.",
+      "ref": "0ebfe765-0275-48b2-ad2d-3aacb5bc6755",
+      "properties": {
+        "hide_marks": false,
+        "button_text": "Continue"
+      },
+      "type": "statement"
+    },
+    {
+      "id": "Sp1N3RIb4FEO",
+      "title": "What is your gender?",
+      "ref": "44659a5e-3640-460a-9614-bd3ae8311043",
       "properties": {
         "randomize": false,
         "allow_multiple_selection": false,
@@ -90,19 +81,19 @@
         "vertical_alignment": true,
         "choices": [
           {
-            "id": "rwFklpTij36Y",
-            "ref": "01FKK5KXV12BWYAMGXJZ5Q0T52",
-            "label": "Not so well..."
+            "id": "Hq797lCsF9jY",
+            "ref": "d3bc0725-4371-42ae-8bb4-0492eff445fb",
+            "label": "Female"
           },
           {
-            "id": "yAF3m8IpcF2S",
-            "ref": "c8c780a6-4210-4673-bf07-4130efde9151",
-            "label": "Terrific!"
+            "id": "dJnYKKeMQl6r",
+            "ref": "d5038c98-41bd-4a70-8910-2c09218b2f98",
+            "label": "Male"
           },
           {
-            "id": "8K30MHQOskcI",
-            "ref": "67554758-9085-45b8-b658-46e5b9686361",
-            "label": "Just OK..."
+            "id": "EzcIaFrzEPQ2",
+            "ref": "2f777442-318c-4789-bd8f-aad348176fc3",
+            "label": "Other"
           }
         ]
       },
@@ -112,59 +103,391 @@
       "type": "multiple_choice"
     },
     {
-      "id": "eiGfabq1jvgJ",
-      "title": "Awesome!",
-      "ref": "awesome",
+      "id": "kS4P8sJJ0MXH",
+      "title": "What is your current occupation?",
+      "ref": "030322e9-7f13-4a11-8bbc-9ecff2a9e20a",
       "properties": {
-        "button_text": "Continue",
-        "hide_marks": false
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "OhOT2e9tltCG",
+            "ref": "c1f10b3f-5d87-4595-b2c3-636668997942",
+            "label": "Student"
+          },
+          {
+            "id": "mVPgykUy15bX",
+            "ref": "895133a7-fa97-40bf-aa14-1b7235c2c3f1",
+            "label": "Employed full-time"
+          },
+          {
+            "id": "mVUSKnIE2Ev5",
+            "ref": "8fb1663d-f498-4352-84f2-f0e3e28e7a80",
+            "label": "Emplyed part-time"
+          },
+          {
+            "id": "FRG4ZWIjCRq1",
+            "ref": "876f51d5-4396-4f98-a84a-1af1e04114f2",
+            "label": "Self-employed"
+          },
+          {
+            "id": "Uzb1fXY3YRdL",
+            "ref": "69f15996-d527-45ec-89b0-a0bdf8eb4e6e",
+            "label": "Unemployed"
+          }
+        ]
       },
-      "type": "statement"
-    },
-    {
-      "id": "SUWzyUxQh6PK",
-      "title": "Oh no!",
-      "ref": "oh_no",
-      "properties": {
-        "button_text": "Continue",
-        "hide_marks": false
-      },
-      "type": "statement"
-    },
-    {
-      "id": "8ObRJNjtp0Pe",
-      "title": "What's your age?",
-      "ref": "whats_your_age",
-      "properties": {},
       "validations": {
         "required": true
       },
-      "type": "number"
+      "type": "multiple_choice"
+    },
+    {
+      "id": "uRT12TZIiAmE",
+      "title": "What is the highest level of school you attended?",
+      "ref": "4ec751ae-44f2-4aea-ba4d-49fc6414efff",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "f0DOk4Yan9du",
+            "ref": "c1f10b3f-5d87-4595-b2c3-636668997942",
+            "label": "I never attended school"
+          },
+          {
+            "id": "tlg8NsXcuiFN",
+            "ref": "cebf85b7-af9f-436b-900a-06eeb9bf0c72",
+            "label": "Primary"
+          },
+          {
+            "id": "f5PcYu5FAlh5",
+            "ref": "895133a7-fa97-40bf-aa14-1b7235c2c3f1",
+            "label": "Secondary"
+          },
+          {
+            "id": "l2wiooZxnqgI",
+            "ref": "876f51d5-4396-4f98-a84a-1af1e04114f2",
+            "label": "Higher"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "G18y485SWSx1",
+      "title": "Many young people have boyfriends or girlfriends.  Are you dating someone?",
+      "ref": "c0db02b6-fda4-4b26-82a0-2ef3271c63b8",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "wSdAXlpvQ9ax",
+            "ref": "c1f10b3f-5d87-4595-b2c3-636668997942",
+            "label": "Yes"
+          },
+          {
+            "id": "u5jAx7A29CZa",
+            "ref": "cebf85b7-af9f-436b-900a-06eeb9bf0c72",
+            "label": "No"
+          },
+          {
+            "id": "duJp6gSlDv1S",
+            "ref": "895133a7-fa97-40bf-aa14-1b7235c2c3f1",
+            "label": "I am married"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "ZVO3hIGJw0MT",
+      "title": "How do you rate your level of English?",
+      "ref": "a92d20ea-2e0b-4dc0-ba9a-156d8c0a0bad",
+      "properties": {
+        "steps": 11,
+        "start_at_one": false,
+        "labels": {
+          "left": "Poor",
+          "center": "Fair",
+          "right": "Excellent"
+        }
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "opinion_scale"
+    },
+    {
+      "id": "b1ROJa4jHlWO",
+      "title": "Have you ever heard of/watched a web series called \"Sex-Ki-Adalat\"?",
+      "ref": "7bc4a3c0-f7d1-4bca-b53c-8fb558c4635f",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "fOAWnClESNel",
+            "ref": "7c009137-6dbd-4711-840a-bb986b2a3e9b",
+            "label": "Yes, I have heard of it"
+          },
+          {
+            "id": "drbL2phgCh4Q",
+            "ref": "78358908-48c4-4b01-8ce3-03422cd815ce",
+            "label": "Yes, I have heard and watched it"
+          },
+          {
+            "id": "lVkYE1mkMzZq",
+            "ref": "e9f9cbcb-3a51-4659-9133-dab8239ffbeb",
+            "label": "No, I don't know anythig about it"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "ECRLI557R977",
+      "title": "Which type of Internet connection do you use most?",
+      "ref": "b2854404-6150-4fb6-8a35-043f625c4d84",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "o24vlcNziPtn",
+            "ref": "110dcf38-5f11-4a14-8b5d-de6264682a17",
+            "label": "Mobile"
+          },
+          {
+            "id": "nHUvYz3gHEf0",
+            "ref": "b932f367-26de-4530-9ad1-b59998bddc01",
+            "label": "Wi-Fi"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "Balu5k5VNcx3",
+      "title": "How often do you watch videos online (e.g., on Facebook, Instagram, YouTube, etc.)?",
+      "ref": "07b3f6e2-0d8e-4fc6-a87b-1f9ba4fbd53e",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "hxmJYm8iq8yx",
+            "ref": "f4d63939-5e72-4433-a50f-5450c175be71",
+            "label": "Every day"
+          },
+          {
+            "id": "UzYkNZBnAyaR",
+            "ref": "b76e6491-3bb3-4213-91e8-35dd1fe9e84d",
+            "label": "A few times a week"
+          },
+          {
+            "id": "rGvlpSKeblpM",
+            "ref": "e350f246-a5ab-4ae0-89f6-d2a344b4887a",
+            "label": "A few times a month"
+          },
+          {
+            "id": "IP5xnN2NgGza",
+            "ref": "4d5d6fad-7449-44f9-b579-a00037f371ed",
+            "label": "Never"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "SraxsmxeqkIm",
+      "title": "Thank you for your time.\nOnly 4 questions are left!\n \nNow we would like to know how you and others feel about the role of women in the society. First, we will ask about your own opinion. Then we will ask you about other people’s opinion. \nKeep in mind that your answers will remain confidential.",
+      "ref": "8c45373f-6c10-401d-a2af-fd1ba0cefd8f",
+      "properties": {
+        "hide_marks": false,
+        "button_text": "Continue"
+      },
+      "type": "statement"
+    },
+    {
+      "id": "TsQpRfyk8naN",
+      "title": "In your opinion, should a woman be banned from entering the kitchen or household shrine during her periods? ",
+      "ref": "8fe4e1a5-3b67-49e6-8475-4ff706d61e0d",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "CnTkdGbdYOav",
+            "ref": "ec2cdf07-86fe-47e3-a856-b680758df57e",
+            "label": "Yes"
+          },
+          {
+            "id": "NW0EALNgk7xG",
+            "ref": "c1d48854-6225-4085-a860-10ea27c4ffa6",
+            "label": "No"
+          },
+          {
+            "id": "q0RnkIFSBO3R",
+            "ref": "33a9f862-6785-4130-8f43-fe060dbf4a67",
+            "label": "Don't know"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "uUg9XklTT772",
+      "title": "Now imagine to pick 10 of your Facebook friends.\n \nAccording to you, how many of them think that a woman should be banned from entering the kitchen or household shrine during her periods? ",
+      "ref": "80c3179a-7a7d-470c-91f8-1165020140c0",
+      "properties": {
+        "steps": 10,
+        "shape": "user"
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "rating"
+    },
+    {
+      "id": "KNzG8lPncWoa",
+      "title": "In your opinion, is a husband justified in hitting or beating his wife if he suspects her of being unfaithful?",
+      "ref": "04dd406f-dd7b-458f-8616-e4262f63f7b8",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "uXHGhA03Q54f",
+            "ref": "ec2cdf07-86fe-47e3-a856-b680758df57e",
+            "label": "Yes"
+          },
+          {
+            "id": "czULJlPu2ffD",
+            "ref": "c1d48854-6225-4085-a860-10ea27c4ffa6",
+            "label": "No"
+          },
+          {
+            "id": "sABVxhuvI7WY",
+            "ref": "33a9f862-6785-4130-8f43-fe060dbf4a67",
+            "label": "Don't know"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "KUHfTbYKpRB2",
+      "title": "Now imagine to pick 10 of your Facebook friends.\n \nAccording to you, how many of them think that a husband is justified in hitting or beating his wife if he suspects her of being unfaithful?",
+      "ref": "f581b4dd-fcb4-46e7-b18e-7fe9f6ed2517",
+      "properties": {
+        "steps": 10,
+        "shape": "user"
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "rating"
+    },
+    {
+      "id": "C6RYYF1LHaMA",
+      "title": "Would you like to know what your Facebook friends actually think about the role of women in the society? \n\nYou can share an anonymous poll through your Facebook wall to it find out!",
+      "ref": "d7b4c644-fca7-4761-b0e0-dcf241ad9555",
+      "validations": {
+        "required": true
+      },
+      "type": "legal"
+    },
+    {
+      "id": "AgR9MVYQdP9r",
+      "title": "Thank you for your time! We will get in touch soon! \nIn the coming days we will send you a short video that you can watch for free. ",
+      "ref": "be74090e-2c4d-4f38-aabc-3e1673df7d7c",
+      "properties": {
+        "hide_marks": false,
+        "button_text": "Continue"
+      },
+      "type": "statement"
     }
   ],
   "logic": [
     {
       "type": "field",
-      "ref": "how_is_your_day",
+      "ref": "378caa71-fc4f-4041-8315-02b6f33616b9",
       "actions": [
         {
           "action": "jump",
           "details": {
             "to": {
               "type": "field",
-              "value": "awesome"
+              "value": "3edb7fcc-748c-461c-bacd-593c043c5518"
             }
           },
           "condition": {
-            "op": "is",
+            "op": "or",
             "vars": [
               {
-                "type": "field",
-                "value": "how_is_your_day"
+                "op": "lower_than",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "378caa71-fc4f-4041-8315-02b6f33616b9"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 15
+                  }
+                ]
               },
               {
-                "type": "choice",
-                "value": "c8c780a6-4210-4673-bf07-4130efde9151"
+                "op": "greater_than",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "378caa71-fc4f-4041-8315-02b6f33616b9"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 24
+                  }
+                ]
               }
             ]
           }
@@ -174,35 +497,86 @@
           "details": {
             "to": {
               "type": "field",
-              "value": "oh_no"
+              "value": "0ebfe765-0275-48b2-ad2d-3aacb5bc6755"
             }
           },
           "condition": {
-            "op": "is_not",
-            "vars": [
-              {
-                "type": "field",
-                "value": "how_is_your_day"
-              },
-              {
-                "type": "choice",
-                "value": "c8c780a6-4210-4673-bf07-4130efde9151"
-              }
-            ]
+            "op": "always",
+            "vars": []
           }
         }
       ]
     },
     {
       "type": "field",
-      "ref": "awesome",
+      "ref": "4cc5c31b-6d23-4d50-8536-7abf1cdf0782",
       "actions": [
         {
           "action": "jump",
           "details": {
             "to": {
               "type": "field",
-              "value": "whats_your_age"
+              "value": "378caa71-fc4f-4041-8315-02b6f33616b9"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "4cc5c31b-6d23-4d50-8536-7abf1cdf0782"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "default_tys"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "3edb7fcc-748c-461c-bacd-593c043c5518",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "default_tys"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "be74090e-2c4d-4f38-aabc-3e1673df7d7c",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "default_tys"
             }
           },
           "condition": {
@@ -213,10 +587,7 @@
       ]
     }
   ],
-  "created_at": "2021-11-03T15:10:28+00:00",
-  "last_updated_at": "2022-02-16T12:04:36+00:00",
-  "published_at": "2021-11-04T16:37:58+00:00",
   "_links": {
-    "display": "https://qaexgf20gqj.typeform.com/to/DjlXLX2s"
+    "display": "https://nandanrao.typeform.com/to/ODf5n7"
   }
 }

--- a/websurvey/mocks/sample.json
+++ b/websurvey/mocks/sample.json
@@ -34,12 +34,28 @@
       "title": "Welcome! 😀\nWe are a team of researchers conducting a study about life and opinions of young people in India. In the coming weeks, we will share with you some nice and short videoclips that you can watch for free. We will also ask you some questions about them. If you agree to take part to this study and you answer our questions, then you will have the chance of winning up to *10 Samsung Galaxy s8!*\n\nYour answers will always remain confidential.\n\nBy clicking the Accept botton, you confirm you have read and accept the _General Terms and Conditions_ contained in the Consent Form available at the link below.\n",
       "ref": "4cc5c31b-6d23-4d50-8536-7abf1cdf0782",
       "properties": {
-        "description": "https://drive.google.com/file/d/1Eovlbbysgdip6cwOfgl6r-r6nkoR1wyT/view?usp=sharing"
+        "description": "https://drive.google.com/file/d/1Eovlbbysgdip6cwOfgl6r-r6nkoR1wyT/view?usp=sharing",
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "Hq797lCsF9jY",
+            "ref": "Accept",
+            "label": "I accept"
+          },
+          {
+            "id": "dJnYKKeMQl6r",
+            "ref": "I do accept",
+            "label": "I do not accept"
+          }
+        ]
       },
       "validations": {
         "required": true
       },
-      "type": "legal"
+      "type": "multiple_choice"
     },
     {
       "id": "zGz4q4dPLUiB",
@@ -528,7 +544,7 @@
               },
               {
                 "type": "constant",
-                "value": true
+                "value": "I accept"
               }
             ]
           }

--- a/websurvey/mocks/test-1.json
+++ b/websurvey/mocks/test-1.json
@@ -1,0 +1,971 @@
+{
+  "id": "hqT8V0tx",
+  "type": "quiz",
+  "title": "Routine Immunization - Endline",
+  "workspace": {
+    "href": "https://api.typeform.com/workspaces/yPd8ZS"
+  },
+  "theme": {
+    "href": "https://api.typeform.com/themes/qHWOQ7"
+  },
+  "settings": {
+    "language": "en",
+    "progress_bar": "proportion",
+    "meta": {
+      "allow_indexing": false
+    },
+    "hide_navigation": false,
+    "is_public": true,
+    "is_trial": false,
+    "show_progress_bar": true,
+    "show_typeform_branding": true,
+    "are_uploads_public": false,
+    "show_time_to_complete": true,
+    "pro_subdomain_enabled": false,
+    "capabilities": {
+      "e2e_encryption": {
+        "enabled": false,
+        "modifiable": false
+      }
+    }
+  },
+  "thankyou_screens": [
+    {
+      "id": "25YK3QaTjhuf",
+      "ref": "aabded3e-bb9f-43a7-8b57-de62e5f24f72",
+      "title": "Great! That's all of our questions!",
+      "properties": {
+        "show_button": true,
+        "share_icons": true,
+        "button_mode": "default_redirect",
+        "button_text": "Create a typeform"
+      }
+    },
+    {
+      "id": "DefaultTyScreen",
+      "ref": "default_tys",
+      "title": "Thanks for completing this typeform\nNow *create your own* — it's free, easy, & beautiful",
+      "properties": {
+        "show_button": true,
+        "share_icons": false,
+        "button_mode": "default_redirect",
+        "button_text": "Create a *typeform*"
+      },
+      "attachment": {
+        "type": "image",
+        "href": "https://images.typeform.com/images/2dpnUBBkz2VN"
+      }
+    }
+  ],
+  "fields": [
+    {
+      "id": "glf5ozEDI5Mh",
+      "title": "Please tell us how strongly do you agree or disagree with each of the following statements.",
+      "ref": "statement_agree",
+      "properties": {
+        "button_text": "Continue",
+        "hide_marks": false
+      },
+      "type": "statement"
+    },
+    {
+      "id": "GOzrkyEjzTSj",
+      "title": "Vaccines are important for children to have\n\n- A. Strongly agree\n- B. Tend to agree\n- C. Neither agree nor disagree\n- D. Tend to disagree\n- E. Strongly disagree",
+      "ref": "vaccines_children",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "Hk5dpeyOakJA",
+            "ref": "01FN2QXBSBD359PCG70FH4K5GQ",
+            "label": "A"
+          },
+          {
+            "id": "nreolwKcitVr",
+            "ref": "01FN2QXBSBH2ZXA7Z5H19KHPPB",
+            "label": "B"
+          },
+          {
+            "id": "RJixxS56rrNT",
+            "ref": "01FN2QXBSBSX1DHB1VHYR4K7HH",
+            "label": "C"
+          },
+          {
+            "id": "SLsahILqAECG",
+            "ref": "01FN2QXBSBBKMMSS0HRQW8HA0S",
+            "label": "D"
+          },
+          {
+            "id": "ps4P57ubypwn",
+            "ref": "01FN2QXBSBV36XN6DET8D5FDAF",
+            "label": "E"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "XZ9c8i3XKAvq",
+      "title": "Overall, I think vaccines are safe\n\n- A. Strongly agree\n- B. Tend to agree\n- C. Neither agree nor disagree\n- D. Tend to disagree\n- E. Strongly disagree",
+      "ref": "vaccines_safe",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "dOujjnPgXMWV",
+            "ref": "01FN2QXBSBKTW5W59ZK9RTN2D8",
+            "label": "A"
+          },
+          {
+            "id": "1MIthDkThIw8",
+            "ref": "01FN2QXBSBWQYD265HREEXXRVM",
+            "label": "B"
+          },
+          {
+            "id": "OYAgryhid3rT",
+            "ref": "01FN2QXBSBCMK9S90ZX03TP9FZ",
+            "label": "C"
+          },
+          {
+            "id": "FxmOdGdTB54J",
+            "ref": "01FN2QXBSBA8DFV5YWX3MGVDHV",
+            "label": "D"
+          },
+          {
+            "id": "KtaIeNZ57iYm",
+            "ref": "01FN2QXBSBFJEF9RERQ5AAHCW4",
+            "label": "E"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "8Idnl5ERyDEl",
+      "title": "Overall, I think vaccines are effective\n\n- A. Strongly agree\n- B. Tend to agree\n- C. Neither agree nor disagree\n- D. Tend to disagree\n- E. Strongly disagree",
+      "ref": "vaccines_effective",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "WRDpYC0hzFSo",
+            "ref": "01FN2QXBSB9MA8J0P762NKVAW9",
+            "label": "A"
+          },
+          {
+            "id": "HG1bnf9yURZW",
+            "ref": "01FN2QXBSC544CY8P90T5FGAK1",
+            "label": "B"
+          },
+          {
+            "id": "m1ePcgGpGxnD",
+            "ref": "01FN2QXBSC3YHXE02EBS8M0T3T",
+            "label": "C"
+          },
+          {
+            "id": "R1cU61EjNx2P",
+            "ref": "01FN2QXBSC9BKNZ1S1MSPMP4RC",
+            "label": "D"
+          },
+          {
+            "id": "Wv7JbsBE7C8H",
+            "ref": "01FN2QXBSC0THEJE0ZMQPYKTNJ",
+            "label": "E"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "JQNQcbfBpcTL",
+      "title": "Vaccines are compatible with my religious beliefs\n\n- A. Strongly agree\n- B. Tend to agree\n- C. Neither agree nor disagree\n- D. Tend to disagree\n- E. Strongly disagree",
+      "ref": "vaccines_religion",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "7nrNJAYuhYpm",
+            "ref": "01FN2QXBSCAGWNHNJ03QRW6R5B",
+            "label": "A"
+          },
+          {
+            "id": "mrEHL0aJH08J",
+            "ref": "01FN2QXBSC5R60C95GZAPAE9GB",
+            "label": "B"
+          },
+          {
+            "id": "4sU8vueeRiGx",
+            "ref": "01FN2QXBSCF474TTQNDJEPJ44G",
+            "label": "C"
+          },
+          {
+            "id": "54VOKW8wjWpB",
+            "ref": "01FN2QXBSCN8HWJV20M1D6J3TA",
+            "label": "D"
+          },
+          {
+            "id": "K4ECuAHzJmSV",
+            "ref": "01FN2QXBSCJK2WJYBS8MQJTZA0",
+            "label": "E"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "rZ2xAh7XE30n",
+      "title": "When is the next time your child (or your youngest child) is due a vaccination?\n\n- A. In the next 3 months\n- B. In 3 – 6 months time\n- C. In 6 – 9 months time\n- D. In 9 – 12 months time\n- E. In greater than 12 months time\n- F. Do not know",
+      "ref": "next_vaccine_due",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "gU9s9jL3alTK",
+            "ref": "01FN2QXBSCTZC0KPK55WTY707T",
+            "label": "A"
+          },
+          {
+            "id": "KC9cPkSDanC5",
+            "ref": "01FN2QXBSCSTATNK08TQKPCQZA",
+            "label": "B"
+          },
+          {
+            "id": "TFZ4wLqFSs6e",
+            "ref": "01FN2QXBSC9RATA88DY11P4GNX",
+            "label": "C"
+          },
+          {
+            "id": "Ombiubg0QT67",
+            "ref": "01FN2QXBSC04ZYV9C74P3SG417",
+            "label": "D"
+          },
+          {
+            "id": "Zw3oynegnRLf",
+            "ref": "01FN2QXBSCVKGDFQEBTFDXV7FV",
+            "label": "E"
+          },
+          {
+            "id": "1g9jHcsYzX7q",
+            "ref": "01FN2QXBSC10BXCWSZ57G0FK3E",
+            "label": "F"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "y6KN9cPBJGCU",
+      "title": "Do you have an appointment booked for your child’s next vaccination?",
+      "ref": "appointment_booked",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "G3Yio9DS0GUj",
+            "ref": "01FN2QXBSCASW7V1FPKEP0SKW3",
+            "label": "Yes"
+          },
+          {
+            "id": "n6naUDyk0KG0",
+            "ref": "01FN2QXBSC8PBCAW0HP24YSZJS",
+            "label": "No"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "90MtkdXZrQ2C",
+      "title": "Do you intend to get your child vaccinated when their next vaccination is due?\n\n- A. Yes, definitely\n- B. Yes, possibly\n- C. No, unlikely\n- D. No, definitely not",
+      "ref": "vaccination_intention",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "DKObySAG6G8F",
+            "ref": "01FN2QXBSC6VNWAYKPPHER1H84",
+            "label": "A"
+          },
+          {
+            "id": "VP4BYvbsXqxS",
+            "ref": "01FN2QXBSCPJRT4C8DKHG7BCZY",
+            "label": "B"
+          },
+          {
+            "id": "T3DnGYwcIrLW",
+            "ref": "01FN2QXBSCBD63FJKQZ5KPAG80",
+            "label": "C"
+          },
+          {
+            "id": "1boG4F3qvUg1",
+            "ref": "01FN2QXBSCTP0K6E7HCV6WZNDH",
+            "label": "D"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "PdpXfxc6G2zT",
+      "title": "Please select your level of agreement with the following statements",
+      "ref": "statement_agree_2",
+      "properties": {
+        "button_text": "Continue",
+        "hide_marks": false
+      },
+      "type": "statement"
+    },
+    {
+      "id": "lfPt8UzisAQy",
+      "title": "I feel it is important to vaccinate my child(ren) on time for their routine vaccinations.\n\n- A. Strongly agree\n- B. Tend to agree\n- C. Neither agree nor disagree\n- D. Tend to disagree\n- E. Strongly disagree",
+      "ref": "important_ontime_children",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "PD7MGnDyxvGf",
+            "ref": "01FN2QXBSCEBRH656QZETWDZPT",
+            "label": "A"
+          },
+          {
+            "id": "CWJEW6tqYKFZ",
+            "ref": "01FN2QXBSCHBJVMP33WC8Y4NXZ",
+            "label": "B"
+          },
+          {
+            "id": "n3v8M8euDRZN",
+            "ref": "01FN2QXBSCG9J8WKP0906FB65X",
+            "label": "C"
+          },
+          {
+            "id": "UPqrfRblbC5f",
+            "ref": "01FN2QXBSCGF8WDX388ZJM8M1P",
+            "label": "D"
+          },
+          {
+            "id": "UJwvCtQZKJqY",
+            "ref": "01FN2QXBSCDKRBW12TDMD5CF9Z",
+            "label": "E"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "IZdOgF2Wk0lG",
+      "title": "I feel it is safe to go to the general practice to vaccinate my child(ren) on time for their routine vaccinations.\n\n- A. Strongly agree\n- B. Tend to agree\n- C. Neither agree nor disagree\n- D. Tend to disagree\n- E. Strongly disagree",
+      "ref": "safe_general_practice",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "XfoIZTu9AJhL",
+            "ref": "01FN2QXBSCJK84E17AW1QRWNW4",
+            "label": "A"
+          },
+          {
+            "id": "OcJJ6vnjGPzD",
+            "ref": "01FN2QXBSCQ9H960N6SQX51RHC",
+            "label": "B"
+          },
+          {
+            "id": "fVdgDBAgxgYN",
+            "ref": "01FN2QXBSC7AMESH0ATV44WXTJ",
+            "label": "C"
+          },
+          {
+            "id": "PXAsLaj2XFOY",
+            "ref": "01FN2QXBSC63SE18HGCN7NT6BX",
+            "label": "D"
+          },
+          {
+            "id": "C4nbXoEaYMUD",
+            "ref": "01FN2QXBSCEZ9RAHHJVA09N5CK",
+            "label": "E"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "18kYWGRABRTR",
+      "title": "Most people who are important to me (e.g. friends, family, community etc) think that I should take my child(ren) to my local GP practice for their routine vaccinations during the coronavirus pandemic\n\n- A. Strongly agree\n- B. Tend to agree\n- C. Neither agree nor disagree\n- D. Tend to disagree\n- E. Strongly disagree",
+      "ref": "friends_family_important",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "X6UAiDDdYYNR",
+            "ref": "01FN2QXBSCVSXN3NQ4EJBKG6W8",
+            "label": "A"
+          },
+          {
+            "id": "L8f1qtmjzZl4",
+            "ref": "01FN2QXBSC3F37DH3TNTGRBXK0",
+            "label": "B"
+          },
+          {
+            "id": "J0EDqCd0P5WB",
+            "ref": "01FN2QXBSC78EX8QQPB6MFYKZ8",
+            "label": "C"
+          },
+          {
+            "id": "XQLZ5ip3PwGU",
+            "ref": "01FN2QXBSC654WS9PGQYPERQAC",
+            "label": "D"
+          },
+          {
+            "id": "tpNRTTlIInDA",
+            "ref": "01FN2QXBSCME4ET6A3GP6A86A5",
+            "label": "E"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "xJsAkgbrvho2",
+      "title": "I feel that the current constraints due to the coronavirus pandemic would make it difficult for me to make a vaccination appointment at my general practice\n\n- A. Strongly agree\n- B. Tend to agree\n- C. Neither agree nor disagree\n- D. Tend to disagree\n- E. Strongly disagree",
+      "ref": "covid_difficult",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "13tzcaa99TVR",
+            "ref": "01FN2QXBSCNR10W232PPE97FQ8",
+            "label": "A"
+          },
+          {
+            "id": "3dELPBle1wMZ",
+            "ref": "01FN2QXBSCJERFZK3BTDD3W1GB",
+            "label": "B"
+          },
+          {
+            "id": "SrzcYPyosatj",
+            "ref": "01FN2QXBSCC7CE1GN7RJF1ME1N",
+            "label": "C"
+          },
+          {
+            "id": "s7JPv0T87BO7",
+            "ref": "01FN2QXBSCAYJKTB5QMYPV9872",
+            "label": "D"
+          },
+          {
+            "id": "ppZpV3VYqwa2",
+            "ref": "01FN2QXBSCAC808NQR6HKRWWGE",
+            "label": "E"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "zozuRknmpqlo",
+      "title": "What immunisations do you know of that are currently available for children?",
+      "ref": "known_immunizations",
+      "properties": {},
+      "validations": {
+        "required": false
+      },
+      "type": "short_text"
+    },
+    {
+      "id": "0K8gcSJFmobS",
+      "title": "Have you ever refused or delayed any immunisations your [child has / children have] been offered from age 0-4 years?\n\n- A. Had all immunisations done at the time they were due \n- B. Not had when due and then gone on to have the immunisation later\n- C. Not had when due. Intend to have the immunisation later, but not done yet\n- D. Not had when due and not sure whether or not to have immunisation\n- E. Not had when due and no plans to have the immunisation\n- F. Refused",
+      "ref": "delayed_immunization",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "YfxmMH88dpA6",
+            "ref": "01FN2QXBSD8MJY357YJR66S8P4",
+            "label": "A"
+          },
+          {
+            "id": "eQuKqySqAgF5",
+            "ref": "01FN2QXBSDCGMC4DD4PV61MJHP",
+            "label": "B"
+          },
+          {
+            "id": "3CkmUuQZ8wSs",
+            "ref": "01FN2QXBSDSD0EQETTBM5S69H7",
+            "label": "C"
+          },
+          {
+            "id": "1FQqZKThTeiS",
+            "ref": "01FN2QXBSDJM6JK51WFSN4PXJQ",
+            "label": "D"
+          },
+          {
+            "id": "c5rCwNeZSHE7",
+            "ref": "01FN2QXBSDHQSJH2HYMMR7BH85",
+            "label": "E"
+          },
+          {
+            "id": "XNgk92ly431U",
+            "ref": "01FN2QXBSD2G9018GDDP37WSND",
+            "label": "F"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "AciLLc1ik99x",
+      "title": "Have you seen or heard or read any adverts, information or publicity for childhood immunisation recently?\n",
+      "ref": "seen_adverts",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "K60xrsgxTMq3",
+            "ref": "01FN2QXBSDM9YZ21DCAB4079FT",
+            "label": "Yes"
+          },
+          {
+            "id": "7LYBfp6pkydU",
+            "ref": "01FN2QXBSDJZ1MFABGMABXKYY1",
+            "label": "No"
+          },
+          {
+            "id": "AvMdEjiEOKWq",
+            "ref": "01FN2QXBSDK2298Y7QJF6NZND4",
+            "label": "Don't Know"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "SVk9CyTScp9P",
+      "title": "Which best describes the information you have found online about vaccines?\n\n-A. Mainly pro-vaccination\n-B. Mainly neutral\n-C. Mainly anti-vaccination",
+      "ref": "online_info_skew",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "tl4PvhC4w5B9",
+            "ref": "01FN2QXBSDNTWR9KGG5QFFWGFD",
+            "label": "A"
+          },
+          {
+            "id": "VUSWzgaXywM2",
+            "ref": "01FN2QXBSDDEA23TF35J5GPAAQ",
+            "label": "B"
+          },
+          {
+            "id": "l0dEcXeuAfsI",
+            "ref": "01FN2QXBSDMNYZ2RXV9JZF2WJM",
+            "label": "C"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "uU5qp8FiU5PX",
+      "title": "Did you see or hear any information which might have persuaded you not to immunise yourself/your child/children?\n",
+      "ref": "info_persuaded_against",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "lh2Owz5hyChH",
+            "ref": "01FN2QXBSD5CPWNKJJE64SF6EC",
+            "label": "Yes"
+          },
+          {
+            "id": "sbrw3cOBuF3U",
+            "ref": "01FN2QXBSDWA0JM33QVZVWBVM8",
+            "label": "No"
+          },
+          {
+            "id": "W2Yl7PzIltA9",
+            "ref": "01FN2QXBSD1N8E0MKXXS57VE8H",
+            "label": "Don't Know"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "P3pYAnbov3bY",
+      "title": "What was the information you saw or heard that might have persuaded you not to immunise yourself/your child/children?",
+      "ref": "info_persuaded_against_details",
+      "properties": {
+        "description": "If yes"
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "short_text"
+    },
+    {
+      "id": "SnJRrei75WYe",
+      "title": "Did you see or hear any information which might have persuaded you to go ahead and immunise yourself/your child/children?",
+      "ref": "info_persuaded_pro",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "CgBoWcFEwqm0",
+            "ref": "01FN2QXBSDRND8S41N0MNABNTJ",
+            "label": "Yes"
+          },
+          {
+            "id": "gNIfeIa2ILza",
+            "ref": "01FN2QXBSDPYXB1BACDT7V44EG",
+            "label": "No"
+          },
+          {
+            "id": "WPy14qa04RJh",
+            "ref": "01FN2QXBSDHV7NKNY9E9RR3KY6",
+            "label": "Don't Know"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "naIl7JGGB1u3",
+      "title": "Did you see or hear any information which might have persuaded you to delay vaccination, as you were unsure what to do?",
+      "ref": "info_persuaded_delay",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "ZFHS2FXwQgRs",
+            "ref": "01FN2QXBSD7NQB0Q4W84TQ6WFT",
+            "label": "Yes"
+          },
+          {
+            "id": "wOpko0W9S60R",
+            "ref": "01FN2QXBSDYTQPVGK07RK4AZZE",
+            "label": "No"
+          },
+          {
+            "id": "HgDsCMkZjkJq",
+            "ref": "01FN2QXBSDXMRE9W42KNPD8D1K",
+            "label": "Don't Know"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "TLP4lQm78sfV",
+      "title": "When making decisions about vaccination, where do you get your information?\n\n- A. Healthcare provider (e.g. doctor/GP, nurse, midwife, pharmacist)\n- B. Public health official\n- C. Family\n- D. Friends\n- E. Religious leaders\n- F. Political leaders\n- G. News media (television, radio, newspapers)\n- H. Internet \n- I. Social media (e.g. WhatsApp, Facebook)\n- J. Other\n- K. Don’t know",
+      "ref": "information_source",
+      "properties": {
+        "description": "ROTATE CODES 1-11. What to do about multiple selection?",
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "l8Oh9rRfpTLp",
+            "ref": "01FN2QXBSDATC1KS5AT3BMC8VX",
+            "label": "A"
+          },
+          {
+            "id": "xFyEGjgyQZCU",
+            "ref": "01FN2QXBSDKR34FRB4DRGESG7V",
+            "label": "B"
+          },
+          {
+            "id": "TiRUWEEvnbhg",
+            "ref": "01FN2QXBSDVBZ32T1P257ZK8TQ",
+            "label": "C"
+          },
+          {
+            "id": "3xM2sOrMpdG5",
+            "ref": "01FN2QXBSDYA25FSX80ZREJV04",
+            "label": "D"
+          },
+          {
+            "id": "K75wg2XE60Qq",
+            "ref": "01FN2QXBSDP560X8SB9V7CB6Q3",
+            "label": "E"
+          },
+          {
+            "id": "KSTSdSysRA71",
+            "ref": "01FN2QXBSD6P7H6HPSKH8GFVVT",
+            "label": "F"
+          },
+          {
+            "id": "wCTV514DwYB2",
+            "ref": "01FN2QXBSDVD6DNWFCA59JTGCN",
+            "label": "G"
+          },
+          {
+            "id": "XH27rUrTFQ7v",
+            "ref": "01FN2QXBSDQC8JWM5NJ3T3CMTN",
+            "label": "H"
+          },
+          {
+            "id": "jsxW51Rgd76v",
+            "ref": "01FN2QXBSD3W6SKAN6XM6MQ7PG",
+            "label": "I"
+          },
+          {
+            "id": "sxM5xgdu25Tj",
+            "ref": "01FN2QXBSDXT7A2G7FS7AH9H43",
+            "label": "J"
+          },
+          {
+            "id": "TogPfXNpKr4s",
+            "ref": "01FN2QXBSD6VEJF8GWKW33RVB9",
+            "label": "K"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "1Wg0QWDeAhzo",
+      "title": "Please specify",
+      "ref": "specify_other_source",
+      "properties": {
+        "description": "If other"
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "short_text"
+    }
+  ],
+  "logic": [
+    {
+      "type": "field",
+      "ref": "appointment_booked",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "vaccination_intention"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "appointment_booked"
+              },
+              {
+                "type": "choice",
+                "value": "01FN2QXBSC8PBCAW0HP24YSZJS"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "statement_agree_2"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "information_source",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "specify_other_source"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "information_source"
+              },
+              {
+                "type": "choice",
+                "value": "01FN2QXBSDXT7A2G7FS7AH9H43"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "default_tys"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "info_persuaded_against",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "info_persuaded_against_details"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "info_persuaded_against"
+              },
+              {
+                "type": "choice",
+                "value": "01FN2QXBSD5CPWNKJJE64SF6EC"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "info_persuaded_pro"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    }
+  ],
+  "_links": {
+    "display": "https://nandanrao.typeform.com/to/hqT8V0tx"
+  }
+}

--- a/websurvey/mocks/test-2.json
+++ b/websurvey/mocks/test-2.json
@@ -1,0 +1,843 @@
+{
+  "id": "zlIadaHG",
+  "type": "quiz",
+  "title": "Routine Immunization - Baseline",
+  "workspace": {
+    "href": "https://api.typeform.com/workspaces/yPd8ZS"
+  },
+  "theme": {
+    "href": "https://api.typeform.com/themes/qHWOQ7"
+  },
+  "settings": {
+    "language": "en",
+    "progress_bar": "proportion",
+    "meta": {
+      "allow_indexing": false
+    },
+    "hide_navigation": false,
+    "is_public": true,
+    "is_trial": false,
+    "show_progress_bar": true,
+    "show_typeform_branding": true,
+    "are_uploads_public": false,
+    "show_time_to_complete": true,
+    "pro_subdomain_enabled": false,
+    "capabilities": {
+      "e2e_encryption": {
+        "enabled": false,
+        "modifiable": false
+      }
+    }
+  },
+  "thankyou_screens": [
+    {
+      "id": "pTJbsWA1ZRc1",
+      "ref": "thankyou_optout",
+      "title": "Ok, no problem. Thank you for your time!",
+      "properties": {
+        "show_button": true,
+        "share_icons": true,
+        "button_mode": "default_redirect",
+        "button_text": "again"
+      }
+    },
+    {
+      "id": "ycJdVqOazUo6",
+      "ref": "thankyou_early",
+      "title": "I'm sorry, we are only looking to survey parents of young children, therefore you are not eligible for this survey. Thanks for taking the time!",
+      "properties": {
+        "show_button": true,
+        "share_icons": true,
+        "button_mode": "default_redirect",
+        "button_text": "again"
+      }
+    },
+    {
+      "id": "DefaultTyScreen",
+      "ref": "default_tys",
+      "title": "Thanks for completing this typeform\nNow *create your own* — it's free, easy, & beautiful",
+      "properties": {
+        "show_button": true,
+        "share_icons": false,
+        "button_mode": "default_redirect",
+        "button_text": "Create a *typeform*"
+      },
+      "attachment": {
+        "type": "image",
+        "href": "https://images.typeform.com/images/2dpnUBBkz2VN"
+      }
+    }
+  ],
+  "fields": [
+    {
+      "id": "MEyhpvvjCcnC",
+      "title": "Hello! We are running a survey for people with children ages 0-2, and we would like to ask you a few questions. \n\nThis survey will take only x minutes of your time, in total. We would like to ask you some questions today and some questions in a few weeks. Upon completion of the final questions in a few weeks time, you will receive X in mobile credit added to a number you provide.  \n\nWould you like to participate? If so, please click \"OK\" to continue.",
+      "ref": "intro_1",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "WZOStP3kS8RC",
+            "ref": "01FN2Q4Y79K34Q3MDJS75EN6BX",
+            "label": "OK"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "J3R6tZkIUbRU",
+      "title": "Great, thanks!\n\nYour answers will be stored securely and kept confidential, they will only be seen by the research team. If at any time you wish to see your personal data or request that all your personal data be deleted, you can write an email to privacy@vlab.digital.\n\nYou can delete this thread after you have finished the survey, to keep your answers private from anyone else using your phone. \n",
+      "ref": "intro_2",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "VeIStT6yWrLU",
+            "ref": "01FN2Q4Y7A1RVB3M1VNF3XKX1R",
+            "label": "OK"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "J6nB5ISUmT7C",
+      "title": "If at any point during the survey you stop responding, we will send a single reminder message. If you wish to stop the survey, you can stop replying.\n\nSome questions will have buttons that you can click on to respond. If there is no button provided, you should use your keyboard to type the answers. ",
+      "ref": "intro_3",
+      "properties": {
+        "button_text": "Continue",
+        "hide_marks": false
+      },
+      "type": "statement"
+    },
+    {
+      "id": "CTJ2xzGngNKy",
+      "title": "Do you accept to participate in the survey?",
+      "ref": "intro_4",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "20UkweYxii0L",
+            "ref": "01FN2Q4Y7A3WNBM02HN860QGKG",
+            "label": "Yes"
+          },
+          {
+            "id": "MwfkZYYfqLxJ",
+            "ref": "01FN2Q4Y7ANCQK0PQNZHJTHZH8",
+            "label": "No"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "W8D5HFy24EUk",
+      "title": "Do you have children between the ages of 0-2",
+      "ref": "has_young_children",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "UTKcApqSS8ae",
+            "ref": "01FN2Q4Y7AHCCKEGPAWVPSWM7D",
+            "label": "Yes"
+          },
+          {
+            "id": "YeU8QsLreIPJ",
+            "ref": "01FN2Q4Y7APVW9F907NFNXSFTY",
+            "label": "No"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "mWPvJueamN31",
+      "title": "What is your gender?",
+      "ref": "gender",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "p62Zl6ramHt9",
+            "ref": "01FN2Q4Y7AJ47K3FRA4KAJZFTP",
+            "label": "Male"
+          },
+          {
+            "id": "xRJxR1MPfr14",
+            "ref": "01FN2Q4Y7AJD19RT7BDSZZXZH7",
+            "label": "Female"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "8TbTR3lWNY6m",
+      "title": "What is your current age in years? [please enter only a number]",
+      "ref": "age",
+      "properties": {},
+      "validations": {
+        "required": false
+      },
+      "type": "number"
+    },
+    {
+      "id": "jSKDOudaOv7q",
+      "title": "In which region do you live?",
+      "ref": "region",
+      "properties": {},
+      "validations": {
+        "required": false
+      },
+      "type": "short_text"
+    },
+    {
+      "id": "NDkxzWcPyqrx",
+      "title": "Which of the following best describes your ethnicity:\n\n-A. Ethnicity A\n-B. Ethnicity B",
+      "ref": "ethnicity",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "AdWX5sV7HjVX",
+            "ref": "3b2c36f5-1ddf-4ea5-a85a-1ee0bfddee05",
+            "label": "A"
+          },
+          {
+            "id": "Vhq9VW43pqSL",
+            "ref": "8b4e2a48-31d7-4420-a72b-9d75fe68eff1",
+            "label": "B"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "YGGxDebawkNl",
+      "title": "What is your Religion?\n\n- A. Roman Catholic\n- B. Protestant\n- C. Orthodox Christian\n- D. Muslim\n- E. Jewish\n- F. Other religion\n- G. No religion",
+      "ref": "religion",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "vRb3y3Hphg46",
+            "ref": "01FN2Q4Y7A35929SGSJ3TQ60ZH",
+            "label": "A"
+          },
+          {
+            "id": "osJjoD5sXZph",
+            "ref": "01FN2Q4Y7AVTBCVDGR20XEJ4QS",
+            "label": "B"
+          },
+          {
+            "id": "Sa9XoVpyEQTX",
+            "ref": "01FN2Q4Y7A4SQ9ZCKKHBKBEJX0",
+            "label": "C"
+          },
+          {
+            "id": "V6PNaqThXTRZ",
+            "ref": "01FN2Q4Y7AD84KF550F10V6ZDV",
+            "label": "D"
+          },
+          {
+            "id": "ET9tm6iO746M",
+            "ref": "01FN2Q4Y7ANMYDWA8YDHT0WX93",
+            "label": "E"
+          },
+          {
+            "id": "Dts2r2C6YyvA",
+            "ref": "01FN2Q4Y7A2A8FA3SPB4VFWE2R",
+            "label": "F"
+          },
+          {
+            "id": "6Q9Lhpr9CTMw",
+            "ref": "01FN2Q4Y7A7V5T2C3CMRN2YQ53",
+            "label": "G"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "kKxUBr95qM3Y",
+      "title": "Which of the following best describes your relationship status:\n\n- A. Married\n- B. In a relationship and living with a partner\n- C. In a relationship but not living with a partner\n- D. Single\n- E. Prefer not to say",
+      "ref": "relationship_status",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "gezkaI6PTTK6",
+            "ref": "01FN2Q4Y7ANH96Y1QT1ERXQXYR",
+            "label": "A"
+          },
+          {
+            "id": "FSZUd2ut6Tnt",
+            "ref": "01FN2Q4Y7AB4JGSZA8TVJ01DMP",
+            "label": "B"
+          },
+          {
+            "id": "CyVt4kmeie3g",
+            "ref": "01FN2Q4Y7AMPGN2JYHP7DC97W1",
+            "label": "C"
+          },
+          {
+            "id": "GrmIm9NbMbkR",
+            "ref": "01FN2Q4Y7AD4M8RN3V0AZM0PA3",
+            "label": "D"
+          },
+          {
+            "id": "0Tj7lJS1lhyj",
+            "ref": "01FN2Q4Y7ANDT470F8ESWEC5F9",
+            "label": "E"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "t1eBVqJKDjWb",
+      "title": "What is the highest level of education you have completed?\n\n- A. No formal education\n- B. Primary level\n- C. Secondary level\n- D. University level\n- E. Masters/PhD\n- F. Other education level\n- G. Prefer not to say",
+      "ref": "education",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "G1oFoaVCyfmA",
+            "ref": "01FN2Q4Y7A22NHN5WAHWBG72MT",
+            "label": "A"
+          },
+          {
+            "id": "0EtkFNQXYH6i",
+            "ref": "01FN2Q4Y7AARWCM24ER9F8RZSK",
+            "label": "B"
+          },
+          {
+            "id": "uaAmy6Om9J0l",
+            "ref": "01FN2Q4Y7AY9DFTA00M5HMXS8M",
+            "label": "C"
+          },
+          {
+            "id": "B8ESNBKDTpca",
+            "ref": "01FN2Q4Y7AYDZVAM95E09X8Y18",
+            "label": "D"
+          },
+          {
+            "id": "lG41uDKMvfcP",
+            "ref": "01FN2Q4Y7A6GR3BTBHMZ101XWG",
+            "label": "E"
+          },
+          {
+            "id": "v9szDbQqc2oV",
+            "ref": "01FN2Q4Y7A6Y53GE8Q4T038164",
+            "label": "F"
+          },
+          {
+            "id": "j8Rz8V4SMYCu",
+            "ref": "01FN2Q4Y7A29YJPSDEP7RT5Z9J",
+            "label": "G"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "sBIdgTw8Dj6b",
+      "title": "Which of the following best describes your employment status?\n\n- A. Working full time (30+ hours per week)\n- B. Working part time (less than 30 hours per week)\n- C. On maternity leave/looking after children full time\n- D. Unemployed\n- E. Student\n- F. Retired\n- G. Other\n- H. Prefer not to say",
+      "ref": "employment_status",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "KaHr3RkVK87J",
+            "ref": "01FN2Q4Y7AQ0ZMMGAYJS1GDY8K",
+            "label": "A"
+          },
+          {
+            "id": "IaZ7WLTpLPmg",
+            "ref": "01FN2Q4Y7AZ0ZZAAMWMX9WHF8P",
+            "label": "B"
+          },
+          {
+            "id": "mYRdEC75KpRd",
+            "ref": "01FN2Q4Y7A8BBE0VETKHYGTZVZ",
+            "label": "C"
+          },
+          {
+            "id": "3RpwqEABKCY9",
+            "ref": "01FN2Q4Y7APMTEYTRYACFKS80B",
+            "label": "D"
+          },
+          {
+            "id": "ODemGFJMa4K8",
+            "ref": "01FN2Q4Y7A2CT269SQ2MA95Y1R",
+            "label": "E"
+          },
+          {
+            "id": "P5khw15uBOda",
+            "ref": "01FN2Q4Y7AM2GZ8WSP7ZMVY53K",
+            "label": "F"
+          },
+          {
+            "id": "61E9Wgpc8VlR",
+            "ref": "01FN2Q4Y7AFFJKSKJFTG3W5FAE",
+            "label": "G"
+          },
+          {
+            "id": "fARypgqMXSTG",
+            "ref": "01FN2Q4Y7AART0YHFVFQ7V2K5J",
+            "label": "H"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "wFRaOBBW3b1d",
+      "title": "How many adults (18+) live in your household? Do not forget to include yourself.",
+      "ref": "num_adults",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "5zZM5GotuEyf",
+            "ref": "01FN2Q4Y7AWHX55E6PN8C92CQB",
+            "label": "1"
+          },
+          {
+            "id": "PU0bwtsNTPz7",
+            "ref": "01FN2Q4Y7AAMH4M2Z2ZYQ4YDCC",
+            "label": "2"
+          },
+          {
+            "id": "5mfBPkGSopVU",
+            "ref": "01FN2Q4Y7AHYKHBCTWW1J0186C",
+            "label": "3"
+          },
+          {
+            "id": "wVYT9Q71Lf6f",
+            "ref": "01FN2Q4Y7ARQVGQBNAVEK8BSKM",
+            "label": "4+"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "zIHyW7uYJ4m8",
+      "title": "How many children aged 0-2 years live in your household? ",
+      "ref": "num_children_2",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "nknyFgs8hoYa",
+            "ref": "01FN2Q4Y7APXCJTFN9FBXHPE16",
+            "label": "1"
+          },
+          {
+            "id": "ZIQxlqOGFoTC",
+            "ref": "01FN2Q4Y7AHM4H4KZFW7FX6KCK",
+            "label": "2"
+          },
+          {
+            "id": "k2EdGKJRaXo2",
+            "ref": "01FN2Q4Y7A61ANRN1ZB3YEMSW6",
+            "label": "3"
+          },
+          {
+            "id": "AvYy7eS0Cqll",
+            "ref": "01FN2Q4Y7AT47VBRADN7PPYWF0",
+            "label": "4+"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "t7dhpJzZGUpr",
+      "title": "How many children aged 3-6 years live in your household? ",
+      "ref": "num_children_6",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "p95cvUqkBcJu",
+            "ref": "01FN2Q4Y7A5H845163X2BNAWRQ",
+            "label": "1"
+          },
+          {
+            "id": "aVcsSoh6yPYF",
+            "ref": "01FN2Q4Y7A8TM6YAADAJ5945ZC",
+            "label": "2"
+          },
+          {
+            "id": "KWXlOYHp3ev1",
+            "ref": "01FN2Q4Y7A3JW7N3B9DZ0T3Q11",
+            "label": "3"
+          },
+          {
+            "id": "0lQmH3JDnXLc",
+            "ref": "01FN2Q4Y7AKA2G4W43B1CP1FKX",
+            "label": "4+"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "IrOy9XRiQjRL",
+      "title": "How many children aged 7-12 years live in your household? ",
+      "ref": "num_children_12",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "pzWYCwBaD07G",
+            "ref": "01FN2Q4Y7AG256ZP3X58DC5RP6",
+            "label": "1"
+          },
+          {
+            "id": "WI02AO72dwqF",
+            "ref": "01FN2Q4Y7AYBZVYWS1P6WH42XX",
+            "label": "2"
+          },
+          {
+            "id": "hCF8ukuvyF64",
+            "ref": "01FN2Q4Y7AC4Z9VW7PTFHDVC9R",
+            "label": "3"
+          },
+          {
+            "id": "f0Gi8132NbJC",
+            "ref": "01FN2Q4Y7ACQ8XEF5MVBA5NYVC",
+            "label": "4+"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "L9Fesx5kK1Dq",
+      "title": "How many children aged 13-17 years live in your household? ",
+      "ref": "num_children_17",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "K9yota84RSEd",
+            "ref": "01FN2Q4Y7AN7BWCQP76ECE73N8",
+            "label": "1"
+          },
+          {
+            "id": "Q3Nw8gajlGCs",
+            "ref": "01FN2Q4Y7AVJYJ4FACNWB7XRJP",
+            "label": "2"
+          },
+          {
+            "id": "dEJwdsTGurc7",
+            "ref": "01FN2Q4Y7AJW6REN8AYGDKJDEN",
+            "label": "3"
+          },
+          {
+            "id": "sXj0vGfEepJ3",
+            "ref": "01FN2Q4Y7BS9PA04ZW1ZSZESAG",
+            "label": "4+"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "jK9cqttVGzff",
+      "title": "Thank you for your time, that is all the questions we have for now. We would like to contact you again in a few weeks to ask you some more questions.\n\nIf you finish the entire survey, you will recieve X in mobile credit to a phone number you provide. \n\nMay we write you again in a few weeks with more questions?",
+      "ref": "thanks_come_again",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "Lw0y6239tz9r",
+            "ref": "01FN2Q4Y7B62V988Q4PRPT88AF",
+            "label": "Yes"
+          },
+          {
+            "id": "aBTunmnvGGbH",
+            "ref": "01FN2Q4Y7B64M9R09DH9XC3F00",
+            "label": "No"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "b2UN5ULnrBzQ",
+      "title": "Click “Notify me” and we will let you know.",
+      "ref": "notify",
+      "properties": {
+        "description": "{\"type\": \"notify\"}",
+        "button_text": "Continue",
+        "hide_marks": false
+      },
+      "type": "statement"
+    },
+    {
+      "id": "Bg69BRLHS0Ga",
+      "title": "Thank you. We will get in touch soon!",
+      "ref": "talk_soon",
+      "properties": {
+        "description": "{\n \"type\": \"wait\",\n \"responseMessage\": \"Sorry, we can't answer any questions now. But we will write you again soon with more questions for our survey. Thank you!\",\n \"wait\": {\n \"type\": \"timeout\",\n \"notifyPermission\": \"true\",\n \"value\": {\n \"type\": \"relative\",\n \"timeout\": \"1 hour\"\n }\n }\n}",
+        "button_text": "Continue",
+        "hide_marks": false
+      },
+      "type": "statement"
+    },
+    {
+      "id": "czGY2PjOOiwi",
+      "title": "Hello again! Would you like to continue taking this survey? It will take X minutes of your time to complete and you will recieve X in mobile credit sent to phone number you provide if you complete all the questions. Click \"Start\" to take the survey.",
+      "ref": "hello_again",
+      "properties": {
+        "description": "{\"type\": \"stitch\", \"form\": \"foo\"}",
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "Gw5eU6qUoyrJ",
+            "ref": "01FN2Q4Y7BEH4WWTTPSSN3YHB1",
+            "label": "Start"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    }
+  ],
+  "logic": [
+    {
+      "type": "field",
+      "ref": "intro_4",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thankyou_optout"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "intro_4"
+              },
+              {
+                "type": "choice",
+                "value": "01FN2Q4Y7ANCQK0PQNZHJTHZH8"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "has_young_children"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "has_young_children",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thankyou_early"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "has_young_children"
+              },
+              {
+                "type": "choice",
+                "value": "01FN2Q4Y7APVW9F907NFNXSFTY"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "gender"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "thanks_come_again",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thankyou_optout"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "thanks_come_again"
+              },
+              {
+                "type": "choice",
+                "value": "01FN2Q4Y7B64M9R09DH9XC3F00"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "notify"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    }
+  ],
+  "_links": {
+    "display": "https://nandanrao.typeform.com/to/zlIadaHG"
+  }
+}

--- a/websurvey/package-lock.json
+++ b/websurvey/package-lock.json
@@ -8,6 +8,7 @@
       "name": "svelte-app",
       "version": "1.0.0",
       "dependencies": {
+        "@vlab-research/translate-typeform": "github:vlab-research/translate-typeform",
         "autoprefixer": "^9.8.8",
         "chai": "^4.3.4",
         "lodash": "^4.17.21",
@@ -220,6 +221,36 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "node_modules/@vlab-research/translate-typeform": {
+      "version": "0.0.32",
+      "resolved": "git+ssh://git@github.com/vlab-research/translate-typeform.git#cbac4bf22f06368af3a9ee1e422eb70a794b6009",
+      "license": "ISC",
+      "dependencies": {
+        "email-validator": "^2.0.4",
+        "js-yaml": "^3.14.0",
+        "phone": "^2.4.4"
+      }
+    },
+    "node_modules/@vlab-research/translate-typeform/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@vlab-research/translate-typeform/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -764,6 +795,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.61.tgz",
       "integrity": "sha512-kpzCOOFlx63C9qKRyIDEsKIUgzoe98ump7T4gU+/OLzj8gYkkWf2SIyBjhTSE0keAjMAp3i7C262YtkQOMYrGw=="
     },
+    "node_modules/email-validator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+      "engines": {
+        "node": ">4.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -797,6 +836,18 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/estree-walker": {
@@ -1820,6 +1871,14 @@
         "node": "*"
       }
     },
+    "node_modules/phone": {
+      "version": "2.4.22",
+      "resolved": "https://registry.npmjs.org/phone/-/phone-2.4.22.tgz",
+      "integrity": "sha512-k2f9qkIgcgbbeyFFMHDcCaYdPxq7u71EjmMvD998PEquwDvIT7zmUFe00S4hH9WPjk+IQlw9W/FlHOu1O17Tbw==",
+      "engines": {
+        "node": ">=6.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
@@ -2447,6 +2506,11 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -3155,6 +3219,34 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@vlab-research/translate-typeform": {
+      "version": "git+ssh://git@github.com/vlab-research/translate-typeform.git#cbac4bf22f06368af3a9ee1e422eb70a794b6009",
+      "from": "@vlab-research/translate-typeform@github:vlab-research/translate-typeform",
+      "requires": {
+        "email-validator": "^2.0.4",
+        "js-yaml": "^3.14.0",
+        "phone": "^2.4.4"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -3565,6 +3657,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.61.tgz",
       "integrity": "sha512-kpzCOOFlx63C9qKRyIDEsKIUgzoe98ump7T4gU+/OLzj8gYkkWf2SIyBjhTSE0keAjMAp3i7C262YtkQOMYrGw=="
     },
+    "email-validator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3593,6 +3690,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "estree-walker": {
       "version": "2.0.2",
@@ -4352,6 +4454,11 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
+    "phone": {
+      "version": "2.4.22",
+      "resolved": "https://registry.npmjs.org/phone/-/phone-2.4.22.tgz",
+      "integrity": "sha512-k2f9qkIgcgbbeyFFMHDcCaYdPxq7u71EjmMvD998PEquwDvIT7zmUFe00S4hH9WPjk+IQlw9W/FlHOu1O17Tbw=="
+    },
     "picocolors": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
@@ -4807,6 +4914,11 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {
       "version": "4.2.3",

--- a/websurvey/package.json
+++ b/websurvey/package.json
@@ -21,6 +21,7 @@
     "svelte": "^3.0.0"
   },
   "dependencies": {
+    "@vlab-research/translate-typeform": "github:vlab-research/translate-typeform",
     "autoprefixer": "^9.8.8",
     "chai": "^4.3.4",
     "lodash": "^4.17.21",

--- a/websurvey/src/components/form/MultipleChoice.svelte
+++ b/websurvey/src/components/form/MultipleChoice.svelte
@@ -4,17 +4,14 @@
 
     export let field, fieldValue, title;
 
-    const { properties } = field;
-    const { choices } = properties;
-
     const dispatch = createEventDispatcher();
 </script>
 
 <label
     for="field-{field.id}"
-    class="text-2xl font-bold tracking-tight text-slate sm:text-2xl">{title}</label>
+    class="text-2xl font-bold tracking-tight text-slate sm:text-xl whitespace-pre-line">{title}</label>
 <div class="space-y-2.5 mb-2">
-    {#each choices as choice, index (choice.id)}
+    {#each field.properties.choices as choice, index (choice.id)}
         <div class="flex flex-row items-center">
             <input
                 bind:group={fieldValue}

--- a/websurvey/src/components/form/MultipleChoice.svelte
+++ b/websurvey/src/components/form/MultipleChoice.svelte
@@ -12,7 +12,7 @@
 
 <label
     for="field-{field.id}"
-    class="text-2xl font-bold tracking-tight text-slate sm:text-3xl mb-2">{title}</label>
+    class="text-2xl font-bold tracking-tight text-slate sm:text-2xl">{title}</label>
 <div class="space-y-2.5 mb-2">
     {#each choices as choice, index (choice.id)}
         <div class="flex flex-row items-center">

--- a/websurvey/src/components/form/Rating.svelte
+++ b/websurvey/src/components/form/Rating.svelte
@@ -1,0 +1,43 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    import { setRequired } from "../../../lib/typewheels/form.js";
+
+    export let field, fieldValue, title;
+
+    const { properties } = field;
+
+    const dispatch = createEventDispatcher();
+
+    const { steps } = properties;
+
+    const arr = [];
+
+    const count = () => {
+        for (let i = 0; i <= steps; i++) {
+            arr.push(i);
+        }
+    };
+
+    count();
+</script>
+
+<label
+    for="field-{field.id}"
+    class="text-2xl font-bold tracking-tight text-slate sm:text-xl whitespace-pre-line">{title}</label>
+<div class="space-y-2.5 mb-2">
+    <div class="flex flex-row justify-between items-start mb-2">
+        {#each arr as e, index}
+            <div class="flex flex-col mr-4">
+                <input
+                    bind:group={fieldValue}
+                    on:input={dispatch('add-field-value', fieldValue)}
+                    required={field.validations.required ? setRequired : null}
+                    type="radio"
+                    name="steps"
+                    value={e}
+                    class="mr-2 mb-2" />
+                <label for="label-{e}" class="sm:text-xl mr-2">{index}</label>
+            </div>
+        {/each}
+    </div>
+</div>

--- a/websurvey/src/components/form/ShortText.svelte
+++ b/websurvey/src/components/form/ShortText.svelte
@@ -9,7 +9,7 @@
 
 <label
     for="field-{field.id}"
-    class="text-2xl font-bold tracking-tight text-slate sm:text-2xl ">{title}</label>
+    class="text-2xl font-bold tracking-tight text-slate sm:text-xl whitespace-pre-line">{title}</label>
 <div>
     <div class="mt-2 mb-2">
         <input
@@ -19,7 +19,7 @@
             type="text"
             id="field-{field.id}"
             autocomplete="off"
-            class="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-2 pr-12 sm:text-xl border-gray-300 rounded-md pt-2 pb-2"
+            class="focus:ring-indigo-500 focus:border-indigo-500 block pl-2 pr-12 sm:text-xl border-gray-300 rounded-md pt-2 pb-2 w-3/4"
             placeholder={field.title} />
     </div>
 </div>

--- a/websurvey/src/components/form/ShortText.svelte
+++ b/websurvey/src/components/form/ShortText.svelte
@@ -9,7 +9,7 @@
 
 <label
     for="field-{field.id}"
-    class="text-2xl font-bold tracking-tight text-slate sm:text-3xl ">{title}</label>
+    class="text-2xl font-bold tracking-tight text-slate sm:text-2xl ">{title}</label>
 <div>
     <div class="mt-2 mb-2">
         <input

--- a/websurvey/src/components/form/Statement.svelte
+++ b/websurvey/src/components/form/Statement.svelte
@@ -1,0 +1,10 @@
+<script>
+    export let title;
+</script>
+
+<div>
+    <h1
+        class="text-2xl font-bold tracking-tight text-slate sm:text-xl whitespace-pre-line">
+        {title}
+    </h1>
+</div>

--- a/websurvey/src/routes/Form.svelte
+++ b/websurvey/src/routes/Form.svelte
@@ -35,7 +35,7 @@
         field = form.fields[index];
         required = field.validations ? field.validations.required : null;
         qa = responseStore.getQa(snapshot);
-        title = responseStore.interpolate(field, qa).title;
+        title = responseStore.interpolate(form, field, qa).title;
     }
 
     const handleSubmit = () => {

--- a/websurvey/src/routes/Form.svelte
+++ b/websurvey/src/routes/Form.svelte
@@ -4,7 +4,8 @@
     import { translateForm, isAQuestion } from "../../lib/typewheels/form.js";
     import MultipleChoice from "../components/form/MultipleChoice.svelte";
     import ShortText from "../components/form/ShortText.svelte";
-    import Statement from "./Statement.svelte";
+    import Statement from "../components/form/Statement.svelte";
+    import Rating from "../components/form/Rating.svelte";
     import Button from "../components/elements/Button.svelte";
     import ProgressBar from "../components/elements/ProgressBar.svelte";
 
@@ -64,32 +65,36 @@
             }
         }
     };
+
+    const lookup = [
+        { type: "short_text", component: ShortText },
+        { type: "number", component: ShortText },
+        { type: "multiple_choice", component: MultipleChoice },
+        { type: "statement", component: Statement },
+        { type: "thankyou_screen", component: Statement },
+        { type: "rating", component: Rating },
+        { type: "opinion_scale", component: Rating },
+    ];
 </script>
 
 <div class="h-screen bg-indigo-50 ">
     <form
         on:submit|preventDefault={handleSubmit}
         class="h-full p-6 max-w-lg mx-auto bg-white rounded-xl shadow-lg flex items-center space-x-4">
-        <div class="space-y-4">
+        <div class="space-y-4 w-full">
             {#if isAQuestion(form, field)}
                 <ProgressBar {form} {field} />
             {/if}
-
-            {#if field.type === 'short_text' || field.type === 'number'}
-                <ShortText
-                    {field}
-                    {title}
-                    bind:fieldValue
-                    on:add-field-value={addFieldValue} />
-            {:else if field.type === 'multiple_choice'}
-                <MultipleChoice
-                    {field}
-                    {title}
-                    bind:fieldValue
-                    on:add-field-value={addFieldValue} />
-            {:else}
-                <Statement {title} />
-            {/if}
+            {#each lookup as option}
+                {#if option.type === field.type}
+                    <svelte:component
+                        this={option.component}
+                        {field}
+                        {title}
+                        bind:fieldValue
+                        on:add-field-value={addFieldValue} />
+                {/if}
+            {/each}
 
             <Button>OK</Button>
         </div>

--- a/websurvey/src/routes/Statement.svelte
+++ b/websurvey/src/routes/Statement.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div>
-    <h1 class="text-2xl font-bold tracking-tight text-slate sm:text-3xl">
+    <h1 class="text-2xl font-bold tracking-tight text-slate sm:text-2xl">
         {title}
     </h1>
 </div>

--- a/websurvey/src/routes/Statement.svelte
+++ b/websurvey/src/routes/Statement.svelte
@@ -1,9 +1,0 @@
-<script>
-    export let title;
-</script>
-
-<div>
-    <h1 class="text-2xl font-bold tracking-tight text-slate sm:text-2xl">
-        {title}
-    </h1>
-</div>


### PR DESCRIPTION
### What changes have you made?
- Refactored `form.js` and `form.test.js` to be a duplicate of the code in `replybot`
- Added in any extra unit tests that do not currently exist in `replybot` 
- Reset the `sample.json` 
- Updated `responsStore.js` and `responseStore.test.js` in line with these changes
- Removed any instances of field type `legal` as we've since decided to deprecate this feature
- Merged #93 into this branch so that it includes components of additional field types `opinion_scale` and `rating`

### Which issue(s) does this PR address?
#88 

### How to test
- Run npm install and open up the web survey on `localhost:5000`
- Check that all tests are passing
- You should be able to switch around the data by importing also the JSON from `test-1` and `test-2` without any breaks in tests or functionality

### Todo
- Create a new version of the `validator` module that is more in line with the needs of the web survey