### PR TITLE
Bugfix/history stack

### DIFF
--- a/websurvey/src/routes/Form.svelte
+++ b/websurvey/src/routes/Form.svelte
@@ -61,7 +61,7 @@
                 if (next.action === "error") {
                     throw new SyntaxError(next.error.message);
                 }
-                navigate(`/${next.ref}`, { replace: true });
+                navigate(`/${next.ref}`, { replace: false });
                 resetFieldValue(fieldValue);
             } catch (e) {
                 alert(e.message);


### PR DESCRIPTION
### What changes have you made?
- Updated the `replace` value to `false` when calling the `navigate` function from "svelte-routing"
- `navigate` is an abstraction of `navigate` from the history.js of the `History` interface
- Previously the history stack was replacing the current entry in the history stack instead of adding a new one. This was preventing the user from navigating backward and forwards using the browser


### Which issue(s) does this PR address?
#91 

### How to test
- Run npm install and open up the web survey on `localhost:5000`
- Navigate through the survey and use the arrows in the browser to go **backward** and **forwards**
- The user should be able to navigate linearly based on the questions they've answered