### PR TITLE
revert(messaging): remove Recurring Notifications implementation

### DIFF
--- a/botserver/README.md
+++ b/botserver/README.md
@@ -4,18 +4,6 @@ Running botserver (dev.sh) will port-forward the app to your localhost:3000. You
 
 Also make sure you have the .env file at the root of the project. This is currently the SAME for both botserver and replybot, so symlink one to the other!
 
-## Webhook Event Types
-
-Botserver processes the following Facebook webhook event types from the `messaging` object:
-
-- **`messaging`**: Regular messages sent by users, including text, attachments, quick replies, and post-back events
-- **`messaging_handovers`**: Thread control handoff events when a user conversation is passed between apps
-- **`messaging_optin`**: Opt-in events when users grant permissions, including:
-  - `notification_messages`: User opts in to receive Marketing Messages
-  - `one_time_notif_req` (OTN): One-time notification requests
-
-All events are normalized and sent to the Kafka event topic for processing downstream.
-
 ## Setup Live Messenger Testing
 
 Go to the test application:

--- a/botserver/server/handlers.js
+++ b/botserver/server/handlers.js
@@ -28,11 +28,8 @@ const handleMessengerEvents = async (ctx, producer, producerReady, eventTopic) =
     try {
       console.log(util.inspect(entry, null, 8))
 
-      // Process all event types:
-      // - messaging: regular messages from users
-      // - messaging_handovers: thread control handoff events
-      // - messaging_optin: opt-in events (e.g., notification_messages, OTN)
-      const eventTypes = ['messaging', 'messaging_handovers', 'messaging_optin']
+      // Process all event types (messaging and messaging_handovers)
+      const eventTypes = ['messaging', 'messaging_handovers']
       
       for (const eventType of eventTypes) {
         if (entry[eventType]) {

--- a/botserver/server/handlers.test.js
+++ b/botserver/server/handlers.test.js
@@ -213,106 +213,14 @@ describe('Botserver Handlers', () => {
 
       // Should produce both events
       producerMock.produce.should.have.been.calledTwice
-
+      
       const calls = producerMock.produce.getCalls()
       const messagingEvent = JSON.parse(calls[0].args[2].toString())
       const handoverEvent = JSON.parse(calls[1].args[2].toString())
-
+      
       messagingEvent.should.have.property('message')
       messagingEvent.message.text.should.equal('Hello')
       handoverEvent.should.have.property('pass_thread_control')
-    })
-
-    it('should process messaging_optin events for notification_messages', async () => {
-      const webhookPayload = {
-        object: 'page',
-        entry: [{
-          messaging_optin: [{
-            sender: { id: 'user123' },
-            recipient: { id: 'page123' },
-            timestamp: 1640995200000,
-            optin: {
-              type: 'notification_messages',
-              notification_messages_token: 'test_nm_token_abc123',
-              notification_messages_timezone: 'America/New_York',
-              token_expiry_timestamp: 1672531200
-            },
-            payload: 'optin_payload_123'
-          }]
-        }]
-      }
-
-      const ctx = {
-        request: { body: webhookPayload },
-        status: 0
-      }
-
-      await handleMessengerEvents(ctx, producerMock, producerReadyMock, 'test-events')
-
-      ctx.status.should.equal(200)
-      producerMock.produce.should.have.been.calledOnce
-
-      const [topic, partition, data, user] = producerMock.produce.firstCall.args
-      topic.should.equal('test-events')
-      user.should.equal('user123')
-
-      const eventData = JSON.parse(data.toString())
-      eventData.source.should.equal('messenger')
-      eventData.should.have.property('optin')
-      eventData.optin.type.should.equal('notification_messages')
-      eventData.optin.notification_messages_token.should.equal('test_nm_token_abc123')
-      eventData.optin.notification_messages_timezone.should.equal('America/New_York')
-      eventData.optin.token_expiry_timestamp.should.equal(1672531200)
-      eventData.payload.should.equal('optin_payload_123')
-    })
-
-    it('should process multiple messaging_optin events', async () => {
-      const webhookPayload = {
-        object: 'page',
-        entry: [{
-          messaging_optin: [
-            {
-              sender: { id: 'user123' },
-              timestamp: 1640995200000,
-              optin: {
-                type: 'notification_messages',
-                notification_messages_token: 'token_user123',
-                notification_messages_timezone: 'America/Los_Angeles',
-                token_expiry_timestamp: 1672531200
-              },
-              payload: 'payload_123'
-            },
-            {
-              sender: { id: 'user456' },
-              timestamp: 1640995201000,
-              optin: {
-                type: 'one_time_notif_req',
-                notification_messages_token: 'token_user456'
-              },
-              payload: 'payload_456'
-            }
-          ]
-        }]
-      }
-
-      const ctx = {
-        request: { body: webhookPayload },
-        status: 0
-      }
-
-      await handleMessengerEvents(ctx, producerMock, producerReadyMock, 'test-events')
-
-      producerMock.produce.should.have.been.calledTwice
-
-      const calls = producerMock.produce.getCalls()
-      const firstEvent = JSON.parse(calls[0].args[2].toString())
-      const secondEvent = JSON.parse(calls[1].args[2].toString())
-
-      firstEvent.sender.id.should.equal('user123')
-      firstEvent.optin.type.should.equal('notification_messages')
-      firstEvent.optin.notification_messages_timezone.should.equal('America/Los_Angeles')
-      secondEvent.sender.id.should.equal('user456')
-      secondEvent.optin.type.should.equal('one_time_notif_req')
     })
 
     it('should handle missing event arrays gracefully', async () => {

--- a/replybot/lib/messenger/index.js
+++ b/replybot/lib/messenger/index.js
@@ -61,12 +61,7 @@ async function sendMessage(data, pageToken) {
   const headers = { Authorization: `Bearer ${pageToken}` }
   const url = `${BASE_URL}/me/messages`
   const fn = () => r2.post(url, { headers, json: data }).json
-  try {
-    return await facebookRequest(fn)
-  } catch (e) {
-    e.details = { ...e.details, payload: data }
-    throw e
-  }
+  return await facebookRequest(fn)
 }
 
 async function passThreadControl(userId, targetAppId, metadata, pageToken) {

--- a/replybot/lib/typewheels/machine.js
+++ b/replybot/lib/typewheels/machine.js
@@ -243,17 +243,9 @@ function tokenWrap(state, nxt, output) {
     return output
   }
 
-  const [tokenObj, ...remainingTokens] = state.tokens
+  const [token, ...tokens] = state.tokens
 
-  // Handle both object format (new) and string format (legacy) for backward compatibility
-  const tokenType = tokenObj.type || 'otn'
-  const tokenString = tokenObj.token || tokenObj
-
-  // Only consume OTN tokens; Marketing Messages tokens persist for reuse
-  const tokensAfterUse = tokenType === 'otn' ? remainingTokens : state.tokens
-
-  // Pass both the token string and type information for recipient field selection
-  return { ...output, token: { type: tokenType, token: tokenString }, stateUpdate: { ...output.stateUpdate, tokens: tokensAfterUse } }
+  return { ...output, token, stateUpdate: { ...output.stateUpdate, tokens } }
 }
 
 function exec(state, nxt) {
@@ -451,35 +443,20 @@ function exec(state, nxt) {
     }
 
     case 'OPTIN': {
-      if (nxt.optin.type === 'one_time_notif_req') {
-        const { one_time_notif_token: token, payload } = nxt.optin
-        const tokenObj = { type: 'otn', token }
-        const tokens = state.tokens ? [...state.tokens, tokenObj] : [tokenObj]
-        return {
-          action: 'RESPOND',
-          stateUpdate: { tokens },
-          response: payload,
-          responseValue: 'optin',
-          question: state.question
-        }
-      } else if (nxt.optin.type === 'notification_messages') {
-        const {
-          notification_messages_token: token,
-          payload,
-          notification_messages_timezone: timezone,
-          token_expiry_timestamp: expires
-        } = nxt.optin
-        const tokenObj = { type: 'marketing_messages', token, timezone, expires }
-        const tokens = state.tokens ? [...state.tokens, tokenObj] : [tokenObj]
-        return {
-          action: 'RESPOND',
-          stateUpdate: { tokens },
-          response: payload,
-          responseValue: 'optin',
-          question: state.question
-        }
-      } else {
+      // only one type of optin supported for now
+      if (nxt.optin.type !== 'one_time_notif_req') {
         return _noop()
+      }
+
+      const { one_time_notif_token: token, payload } = nxt.optin
+      const tokens = state.tokens ? [...state.tokens, token] : [token]
+
+      return {
+        action: 'RESPOND',
+        stateUpdate: { tokens },
+        response: payload,
+        responseValue: 'optin',
+        question: state.question
       }
     }
 
@@ -805,9 +782,7 @@ function _response(
     const message = translateField(ctx, qa, ctx.form.fields[0])
 
     if (token) {
-      const tokenString = token.token || token
-      const tokenType = token.type === 'marketing_messages' ? 'notification_messages_token' : 'one_time_notif_token'
-      return { recipient: { [tokenType]: tokenString }, ...message }
+      return { recipient: { one_time_notif_token: token }, ...message }
     }
 
     return message
@@ -831,10 +806,8 @@ function _response(
   }
 
   if (token) {
-    const tokenString = token.token || token
-    const tokenType = token.type === 'marketing_messages' ? 'notification_messages_token' : 'one_time_notif_token'
     return {
-      recipient: { [tokenType]: tokenString },
+      recipient: { one_time_notif_token: token },
       ...nextQuestion(ctx, qa, question)
     }
   }

--- a/replybot/lib/typewheels/machine.test.js
+++ b/replybot/lib/typewheels/machine.test.js
@@ -7,7 +7,7 @@ const { parseLogJSON } = require('./utils')
 const { followUpMessage, offMessage } = require('@vlab-research/translate-typeform')
 const { _initialState, getMessage, exec, act, apply, getState, getCurrentForm, getWatermark, makeEventMetadata } = require('./machine')
 const form = JSON.parse(fs.readFileSync('mocks/sample.json'))
-const { echo, tyEcho, statementEcho, repeatEcho, delivery, read, qr, text, sticker, multipleChoice, referral, USER_ID, reaction, syntheticBail, syntheticPR, optin, mmOptin, payloadReferral, syntheticRedo, synthetic } = require('./events.test')
+const { echo, tyEcho, statementEcho, repeatEcho, delivery, read, qr, text, sticker, multipleChoice, referral, USER_ID, reaction, syntheticBail, syntheticPR, optin, payloadReferral, syntheticRedo, synthetic } = require('./events.test')
 
 const _echo = md => ({ ...echo, message: { ...echo.message, metadata: md.ref ? md : { ref: md } } })
 
@@ -637,7 +637,7 @@ describe('getState', () => {
     const state = getState(log)
     state.state.should.equal('RESPONDING')
     state.forms[1].should.equal('BAR')
-    state.tokens.should.eql([{ type: 'otn', token: 'FOOBAR' }])
+    state.tokens.should.eql(['FOOBAR'])
   })
 
   it('It moves to next form on bailout when response never sent', () => {
@@ -747,7 +747,7 @@ describe('getState', () => {
     const state = getState(log)
 
     state.state.should.equal('RESPONDING')
-    state.tokens.should.eql([{ type: 'otn', token: 'FOOBAR' }])
+    state.tokens.should.eql(['FOOBAR'])
     state.question.should.equal('foo')
     state.qa.should.eql([['foo', 'optin']])
   })
@@ -1615,128 +1615,6 @@ describe('Machine', () => {
 
     const actions = getMessage(log, form, user)
     JSON.parse(actions.messages[0].message.metadata).repeat.should.be.true
-  })
-
-  it('Validates a Marketing Messages optin when it is a response to a notification_messages request', () => {
-    const form = {
-      logic: [],
-      fields: [{
-        type: 'statement', title: 'foo', ref: 'foo', properties:
-          { description: 'type: notify' }  // Use notify for now since we're testing token extraction, not field translation
-      },
-      { type: 'short_text', title: 'bar', ref: 'bar' }]
-    }
-
-    const log = [referral, echo, mmOptin]
-
-    const actions = getMessage(log, form, user)
-    actions.messages[0].message.text.should.equal('bar')
-  })
-
-  it('stores MM token with metadata (timezone, expires)', () => {
-    const form = {
-      logic: [],
-      fields: [{
-        type: 'statement', title: 'foo', ref: 'foo', properties:
-          { description: 'type: notification_messages' }
-      },
-      { type: 'short_text', title: 'bar', ref: 'bar' }]
-    }
-
-    const log = [referral, echo, mmOptin]
-    const state = getState(log)
-
-    state.tokens.should.exist
-    state.tokens.length.should.equal(1)
-    state.tokens[0].should.have.property('type', 'marketing_messages')
-    state.tokens[0].should.have.property('token', 'MM_TOKEN_123')
-    state.tokens[0].should.have.property('timezone', 'US/Pacific')
-    state.tokens[0].should.have.property('expires', 1704153600000)
-  })
-
-  it('sends messages to MM token with notification_messages_token recipient field', () => {
-    const wait = { type: 'timeout', value: '25 hours', notifyPermission: true }
-
-    const externalEvent = {
-      source: 'synthetic',
-      timestamp: Date.now() + 1000 * 60 * 60 * 25,
-      event: { type: 'timeout', value: Date.now() + 1000 * 60 * 60 * 25 }
-    }
-
-    const d = Date.now()
-
-    const form = {
-      logic: [],
-      fields: [{ type: 'statement', title: 'foo', ref: 'foo', properties: { description: '' } },
-      { type: 'short_text', title: 'bar', ref: 'bar' }]
-    }
-
-    const log = [referral, mmOptin, { ...echo, timestamp: d, message: { ...echo.message, metadata: { wait, ref: 'foo' } } }, externalEvent]
-
-    const actions = getMessage(log, form, user)
-    actions.messages.length.should.equal(1)
-    actions.messages[0].recipient.should.have.property('notification_messages_token', 'MM_TOKEN_123')
-    actions.messages[0].message.text.should.equal('bar')
-  })
-
-  it('does not consume MM token after use (persists for reuse)', () => {
-    const wait = { type: 'timeout', value: '25 hours', notifyPermission: true }
-
-    const externalEvent = {
-      source: 'synthetic',
-      timestamp: Date.now() + 1000 * 60 * 60 * 25,
-      event: { type: 'timeout', value: Date.now() + 1000 * 60 * 60 * 25 }
-    }
-
-    const d = Date.now()
-
-    const form = {
-      logic: [],
-      fields: [{ type: 'statement', title: 'foo', ref: 'foo', properties: { description: '' } },
-      { type: 'short_text', title: 'bar', ref: 'bar' }]
-    }
-
-    const log = [referral, mmOptin, { ...echo, timestamp: d, message: { ...echo.message, metadata: { wait, ref: 'foo' } } }, externalEvent]
-
-    const state = getState(log)
-
-    // After using MM token, it should still exist (not consumed)
-    state.tokens.should.exist
-    state.tokens.length.should.equal(1)
-    state.tokens[0].type.should.equal('marketing_messages')
-  })
-
-  it('OTN token is consumed after use but MM token persists', () => {
-    const wait = { type: 'timeout', value: '25 hours', notifyPermission: true }
-
-    const externalEvent = {
-      source: 'synthetic',
-      timestamp: Date.now() + 1000 * 60 * 60 * 25,
-      event: { type: 'timeout', value: Date.now() + 1000 * 60 * 60 * 25 }
-    }
-
-    const d = Date.now()
-
-    const form = {
-      logic: [],
-      fields: [{ type: 'statement', title: 'foo', ref: 'foo', properties: { description: '' } },
-      { type: 'short_text', title: 'bar', ref: 'bar' }]
-    }
-
-    // Test with OTN token
-    const logOTN = [referral, optin, { ...echo, timestamp: d, message: { ...echo.message, metadata: { wait, ref: 'foo' } } }, externalEvent]
-    const stateOTN = getState(logOTN)
-
-    // OTN token should be consumed
-    stateOTN.tokens.length.should.equal(0)
-
-    // Test with MM token
-    const logMM = [referral, mmOptin, { ...echo, timestamp: d, message: { ...echo.message, metadata: { wait, ref: 'foo' } } }, externalEvent]
-    const stateMM = getState(logMM)
-
-    // MM token should persist
-    stateMM.tokens.length.should.equal(1)
-    stateMM.tokens[0].type.should.equal('marketing_messages')
   })
 
 

--- a/replybot/package.json
+++ b/replybot/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@vlab-research/botspine": "0.0.13",
     "@vlab-research/chatbase-postgres": "^0.1.0",
-    "@vlab-research/translate-typeform": "^0.2.8",
+    "@vlab-research/translate-typeform": "^0.2.7",
     "@vlab-research/utils": "0.0.11",
     "cacheman": "^2.2.1",
     "chrono-node": "^1.3.11",


### PR DESCRIPTION
## Summary

Reverts #133.

Recurring Notifications (`messaging_optin` token flow) was deprecated globally on **February 10, 2026** — two months before this was merged. It only remains available in AU, EU, JP, KR, and UK.

The correct replacement for sending messages outside the 24-hour window globally is **Utility Messages** — a template-based API that requires no user opt-in, works with the existing PSID, and is globally available for non-promotional content (survey results, prize notifications).

## What this reverts

- `botserver/server/handlers.js` — removes `messaging_optin` from event types
- `botserver/server/handlers.test.js` — removes MM-specific tests
- `replybot/lib/typewheels/machine.js` — reverts OPTIN handler and token recipient logic
- `replybot/lib/typewheels/machine.test.js` — removes MM token tests
- `replybot/package.json` — reverts translate-typeform to `^0.2.7`

## Next step

Implement Utility Messages support: `messaging_type: "UTILITY"` + template API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)