### PR TITLE
fix(exodus): use lean BailEventSummary query for bail list to avoid timeout

### DIFF
--- a/documentation/bail-systems.md
+++ b/documentation/bail-systems.md
@@ -506,12 +506,25 @@ GET /users/:userId/bails
 Authorization: Bearer {token}
 ```
 
-> **Performance note.** Each row in this response is enriched with a `last_event`
-> for the "Last Execution" column. The list endpoint resolves all latest events
-> in **one** batched query (`SELECT DISTINCT ON (bail_id) ... WHERE bail_id = ANY($1::uuid[]) ORDER BY bail_id, timestamp DESC` against `idx_bail_events_bail`)
-> rather than fetching the entire event history per bail. This keeps the request
-> O(N distinct bails owned by the user) instead of O(N bails × events_per_bail),
-> which previously overwhelmed the 10s API timeout under accumulated history.
+> **Performance note.** Each row in this response is enriched with a lightweight
+> `last_event` summary for the "Last Execution" column. The list endpoint resolves
+> all latest events in **one** batched query that selects only the small fields the
+> UI needs:
+>
+> ```sql
+> SELECT DISTINCT ON (bail_id)
+>        id, bail_id, event_type, timestamp, users_matched, users_bailed
+> FROM chatroach.bail_events
+> WHERE bail_id = ANY($1::uuid[])
+> ORDER BY bail_id, timestamp DESC
+> ```
+>
+> This projection is fully covered by the existing `idx_bail_events_bail` index,
+> avoiding the heavy JSON audit columns (`definition_snapshot`, `error`,
+> `execution_results`) and primary-table lookups. The first batched fix (commit
+> `8276e15`) reduced the number of rows touched; this second layer reduces the
+> amount of data read per row, which is what caused the timeout to return for
+> users with very large accumulated event history.
 
 **Response** (200 OK):
 ```json
@@ -532,20 +545,20 @@ Authorization: Bearer {token}
       "last_event": {
         "id": "uuid",
         "bail_id": "uuid",
-        "user_id": "uuid",
-        "bail_name": "string",
         "event_type": "execution|error",
         "timestamp": "ISO-8601",
         "users_matched": 0,
-        "users_bailed": 0,
-        "definition_snapshot": {},
-        "error": null,
-        "execution_results": {"user_ids": ["uid1", "uid2"]}
+        "users_bailed": 0
       }
     }
   ]
 }
 ```
+
+> Note: `GET /users/:userId/bails/:id`, `POST /users/:userId/bails`, and
+> `PUT /users/:userId/bails/:id` still return the full `BailResponse` shape with a
+> complete `last_event` (including `definition_snapshot`, `error`, and
+> `execution_results`). Only the list endpoint uses the lean summary.
 
 ### Get Single Bail
 
@@ -776,6 +789,21 @@ Compound conditions:
   ]
 }
 ```
+
+**BailEventSummary** (returned as `last_event` by the list endpoint):
+
+```json
+{
+  "id": "uuid",
+  "bail_id": "uuid",
+  "event_type": "execution|error",
+  "timestamp": "ISO-8601",
+  "users_matched": 0,
+  "users_bailed": 0
+}
+```
+
+The full `BailEvent` (including `definition_snapshot`, `error`, and `execution_results`) is still returned by `GET /users/:userId/bails/:id`, `POST /users/:userId/bails`, and `PUT /users/:userId/bails/:id`.
 
 ### Error Handling
 

--- a/exodus/api/handlers.go
+++ b/exodus/api/handlers.go
@@ -38,7 +38,7 @@ func (s *Server) ListBails(c echo.Context) error {
 		return respondError(c, http.StatusInternalServerError, "database_error", err.Error())
 	}
 
-	bailResponses := make([]*BailResponse, len(dbBails))
+	bailResponses := make([]*BailListItemResponse, len(dbBails))
 	if len(dbBails) == 0 {
 		return c.JSON(http.StatusOK, BailsListResponse{Bails: bailResponses})
 	}
@@ -48,7 +48,7 @@ func (s *Server) ListBails(c echo.Context) error {
 		bailIDs[i] = dbBail.ID
 	}
 
-	latestByID, err := s.db.GetLatestEventsByBailIDs(ctx, bailIDs)
+	latestByID, err := s.db.GetLatestEventSummariesByBailIDs(ctx, bailIDs)
 	if err != nil {
 		return respondError(c, http.StatusInternalServerError, "database_error", err.Error())
 	}
@@ -59,15 +59,12 @@ func (s *Server) ListBails(c echo.Context) error {
 			return respondError(c, http.StatusInternalServerError, "conversion_error", fmt.Sprintf("Failed to convert bail: %v", err))
 		}
 
-		var lastEvent *types.BailEvent
-		if dbEvent, ok := latestByID[dbBail.ID]; ok {
-			lastEvent, err = dbEventToTypesEvent(dbEvent)
-			if err != nil {
-				return respondError(c, http.StatusInternalServerError, "conversion_error", fmt.Sprintf("Failed to convert event: %v", err))
-			}
+		var lastEvent *types.BailEventSummary
+		if dbSummary, ok := latestByID[dbBail.ID]; ok {
+			lastEvent = dbEventSummaryToTypesEventSummary(dbSummary)
 		}
 
-		bailResponses[i] = &BailResponse{
+		bailResponses[i] = &BailListItemResponse{
 			Bail:      typeBail,
 			LastEvent: lastEvent,
 		}
@@ -524,4 +521,17 @@ func dbEventToTypesEvent(dbEvent *db.BailEvent) (*types.BailEvent, error) {
 		Error:              dbEvent.Error,
 		ExecutionResults:   dbEvent.ExecutionResults,
 	}, nil
+}
+
+// dbEventSummaryToTypesEventSummary converts a db.BailEventSummary to the
+// public types.BailEventSummary used by the list endpoint.
+func dbEventSummaryToTypesEventSummary(dbSummary *db.BailEventSummary) *types.BailEventSummary {
+	return &types.BailEventSummary{
+		ID:           dbSummary.ID,
+		BailID:       dbSummary.BailID,
+		EventType:    dbSummary.EventType,
+		Timestamp:    dbSummary.Timestamp,
+		UsersMatched: dbSummary.UsersMatched,
+		UsersBailed:  dbSummary.UsersBailed,
+	}
 }

--- a/exodus/api/handlers_test.go
+++ b/exodus/api/handlers_test.go
@@ -19,15 +19,18 @@ import (
 
 // mockDB implements the database interface for testing
 type mockDB struct {
-	bails                  []*db.Bail
-	events                 []*db.BailEvent
-	queryFunc              func(ctx context.Context, sql string, args ...interface{}) ([]map[string]interface{}, error)
-	createFunc             func(ctx context.Context, bail *db.Bail) error
-	updateFunc             func(ctx context.Context, bail *db.Bail) error
-	deleteFunc             func(ctx context.Context, id uuid.UUID) error
-	latestEventsFunc       func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]*db.BailEvent, error)
-	latestEventsCallCount  int
-	latestEventsLastCalled []uuid.UUID
+	bails                       []*db.Bail
+	events                      []*db.BailEvent
+	queryFunc                   func(ctx context.Context, sql string, args ...interface{}) ([]map[string]interface{}, error)
+	createFunc                  func(ctx context.Context, bail *db.Bail) error
+	updateFunc                  func(ctx context.Context, bail *db.Bail) error
+	deleteFunc                  func(ctx context.Context, id uuid.UUID) error
+	latestEventsFunc            func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]*db.BailEvent, error)
+	latestEventsCallCount       int
+	latestEventsLastCalled      []uuid.UUID
+	latestSummariesFunc         func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]*db.BailEventSummary, error)
+	latestSummariesCallCount    int
+	latestSummariesLastCalled   []uuid.UUID
 }
 
 func (m *mockDB) GetBailsByUser(ctx context.Context, userID uuid.UUID) ([]*db.Bail, error) {
@@ -118,6 +121,39 @@ func (m *mockDB) GetLatestEventsByBailIDs(ctx context.Context, bailIDs []uuid.UU
 		existing, ok := latest[*event.BailID]
 		if !ok || event.Timestamp.After(existing.Timestamp) {
 			latest[*event.BailID] = event
+		}
+	}
+	return latest, nil
+}
+
+func (m *mockDB) GetLatestEventSummariesByBailIDs(ctx context.Context, bailIDs []uuid.UUID) (map[uuid.UUID]*db.BailEventSummary, error) {
+	m.latestSummariesCallCount++
+	m.latestSummariesLastCalled = append([]uuid.UUID(nil), bailIDs...)
+	if m.latestSummariesFunc != nil {
+		return m.latestSummariesFunc(ctx, bailIDs)
+	}
+	latest := make(map[uuid.UUID]*db.BailEventSummary, len(bailIDs))
+	wanted := make(map[uuid.UUID]struct{}, len(bailIDs))
+	for _, id := range bailIDs {
+		wanted[id] = struct{}{}
+	}
+	for _, event := range m.events {
+		if event.BailID == nil {
+			continue
+		}
+		if _, ok := wanted[*event.BailID]; !ok {
+			continue
+		}
+		existing, ok := latest[*event.BailID]
+		if !ok || event.Timestamp.After(existing.Timestamp) {
+			latest[*event.BailID] = &db.BailEventSummary{
+				ID:           event.ID,
+				BailID:       event.BailID,
+				EventType:    event.EventType,
+				Timestamp:    event.Timestamp,
+				UsersMatched: event.UsersMatched,
+				UsersBailed:  event.UsersBailed,
+			}
 		}
 	}
 	return latest, nil
@@ -309,9 +345,9 @@ func TestListBails_AggregatesLatestEventsInOneCall(t *testing.T) {
 	mock := &mockDB{
 		bails:  bails,
 		events: events,
-		latestEventsFunc: func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]*db.BailEvent, error) {
+		latestSummariesFunc: func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]*db.BailEventSummary, error) {
 			if len(ids) == 1 {
-				return nil, fmt.Errorf("GetLatestEventsByBailIDs called per-bail (only %d id)", len(ids))
+				return nil, fmt.Errorf("GetLatestEventSummariesByBailIDs called per-bail (only %d id)", len(ids))
 			}
 			return nil, nil
 		},
@@ -333,26 +369,26 @@ func TestListBails_AggregatesLatestEventsInOneCall(t *testing.T) {
 		t.Fatalf("Expected status 200, got %d (body=%s)", rec.Code, rec.Body.String())
 	}
 
-	if mock.latestEventsCallCount != 1 {
-		t.Errorf("Expected exactly 1 call to GetLatestEventsByBailIDs, got %d", mock.latestEventsCallCount)
+	if mock.latestSummariesCallCount != 1 {
+		t.Errorf("Expected exactly 1 call to GetLatestEventSummariesByBailIDs, got %d", mock.latestSummariesCallCount)
 	}
 
 	expectedIDs := map[uuid.UUID]bool{bailA: false, bailB: false, bailC: false}
-	for _, id := range mock.latestEventsLastCalled {
+	for _, id := range mock.latestSummariesLastCalled {
 		if _, ok := expectedIDs[id]; !ok {
-			t.Errorf("Unexpected bail id passed to GetLatestEventsByBailIDs: %s", id)
+			t.Errorf("Unexpected bail id passed to GetLatestEventSummariesByBailIDs: %s", id)
 		}
 		expectedIDs[id] = true
 	}
 	for id, seen := range expectedIDs {
 		if !seen {
-			t.Errorf("Expected bail id %s to be passed to GetLatestEventsByBailIDs", id)
+			t.Errorf("Expected bail id %s to be passed to GetLatestEventSummariesByBailIDs", id)
 		}
 	}
 
 	// Now drop the sabotage and assert the response shape picks "newest per bail"
 	// and leaves bail C with a nil LastEvent.
-	mock.latestEventsFunc = nil
+	mock.latestSummariesFunc = nil
 	req2 := httptest.NewRequest(http.MethodGet, "/users/"+userID.String()+"/bails", nil)
 	rec2 := httptest.NewRecorder()
 	c2 := server.echo.NewContext(req2, rec2)

--- a/exodus/api/server.go
+++ b/exodus/api/server.go
@@ -19,6 +19,7 @@ type DBInterface interface {
 	DeleteBail(ctx context.Context, id uuid.UUID) error
 	GetEventsByBailID(ctx context.Context, bailID uuid.UUID) ([]*db.BailEvent, error)
 	GetLatestEventsByBailIDs(ctx context.Context, bailIDs []uuid.UUID) (map[uuid.UUID]*db.BailEvent, error)
+	GetLatestEventSummariesByBailIDs(ctx context.Context, bailIDs []uuid.UUID) (map[uuid.UUID]*db.BailEventSummary, error)
 	GetEventsByUser(ctx context.Context, userID uuid.UUID, limit int) ([]*db.BailEvent, error)
 	Query(ctx context.Context, sql string, args ...interface{}) ([]map[string]interface{}, error)
 	Close()

--- a/exodus/api/types.go
+++ b/exodus/api/types.go
@@ -27,9 +27,17 @@ type BailResponse struct {
 	LastEvent *types.BailEvent `json:"last_event,omitempty"`
 }
 
+// BailListItemResponse wraps a bail with a lightweight summary of its most
+// recent event. Used by the list endpoint, which does not need the full audit
+// fields present in BailResponse.LastEvent.
+type BailListItemResponse struct {
+	Bail      *types.Bail             `json:"bail"`
+	LastEvent *types.BailEventSummary `json:"last_event,omitempty"`
+}
+
 // BailsListResponse contains a list of bails with their events
 type BailsListResponse struct {
-	Bails []*BailResponse `json:"bails"`
+	Bails []*BailListItemResponse `json:"bails"`
 }
 
 // EventsListResponse contains a list of bail events

--- a/exodus/db/events.go
+++ b/exodus/db/events.go
@@ -25,6 +25,18 @@ type BailEvent struct {
 	ExecutionResults   *json.RawMessage `json:"execution_results,omitempty"`
 }
 
+// BailEventSummary is a lightweight projection used for the bail list endpoint.
+// It omits the large audit fields (definition_snapshot, error, execution_results)
+// so the query can be fully satisfied by the idx_bail_events_bail index.
+type BailEventSummary struct {
+	ID           uuid.UUID
+	BailID       *uuid.UUID
+	EventType    string
+	Timestamp    time.Time
+	UsersMatched int
+	UsersBailed  int
+}
+
 // RecordEvent inserts a new bail event into the database
 // The event.ID and event.Timestamp will be populated with generated values
 func (d *DB) RecordEvent(ctx context.Context, event *BailEvent) error {
@@ -114,6 +126,60 @@ func (d *DB) GetLatestEventsByBailIDs(ctx context.Context, bailIDs []uuid.UUID) 
 		if event.BailID != nil {
 			latest[*event.BailID] = event
 		}
+	}
+
+	return latest, nil
+}
+
+// GetLatestEventSummariesByBailIDs returns the most recent event summary for
+// each of the given bail IDs, looked up in a single round-trip. The result map
+// is keyed by bail_id; bails with no recorded events are absent from the map
+// (and not an error).
+//
+// This is intended for the bail list endpoint, which only needs the "last
+// execution" metadata (timestamp and user counts) for the UI. The projection
+// avoids the large JSON audit columns (definition_snapshot, error,
+// execution_results) so the query remains fast even as event history grows.
+func (d *DB) GetLatestEventSummariesByBailIDs(ctx context.Context, bailIDs []uuid.UUID) (map[uuid.UUID]*BailEventSummary, error) {
+	latest := make(map[uuid.UUID]*BailEventSummary, len(bailIDs))
+	if len(bailIDs) == 0 {
+		return latest, nil
+	}
+
+	query := `
+		SELECT DISTINCT ON (bail_id)
+		       id, bail_id, event_type, timestamp, users_matched, users_bailed
+		FROM chatroach.bail_events
+		WHERE bail_id = ANY($1::uuid[])
+		ORDER BY bail_id, timestamp DESC
+	`
+
+	rows, err := d.pool.Query(ctx, query, bailIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query latest event summaries for bails: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		summary := &BailEventSummary{}
+		err := rows.Scan(
+			&summary.ID,
+			&summary.BailID,
+			&summary.EventType,
+			&summary.Timestamp,
+			&summary.UsersMatched,
+			&summary.UsersBailed,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan event summary: %w", err)
+		}
+		if summary.BailID != nil {
+			latest[*summary.BailID] = summary
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating event summaries: %w", err)
 	}
 
 	return latest, nil

--- a/exodus/db/events_test.go
+++ b/exodus/db/events_test.go
@@ -603,3 +603,102 @@ func TestGetLatestEventsByBailIDs(t *testing.T) {
 		t.Errorf("Expected otherEvent %s, got %s", otherEvent.ID, entry.ID)
 	}
 }
+
+func TestGetLatestEventSummariesByBailIDs(t *testing.T) {
+	pool := TestPool()
+	defer pool.Close()
+	Before(pool)
+
+	userID := SetupTestUser(t, pool)
+	db := &DB{pool: pool}
+
+	def := CreateTestBailDefinition()
+
+	bailWithEvents := &Bail{
+		UserID:          userID,
+		Name:            "summary-bail-with-events",
+		Definition:      def,
+		DestinationForm: "exit-form",
+	}
+	if err := db.CreateBail(context.Background(), bailWithEvents); err != nil {
+		t.Fatalf("CreateBail failed: %v", err)
+	}
+
+	bailWithoutEvents := &Bail{
+		UserID:          userID,
+		Name:            "summary-bail-without-events",
+		Definition:      def,
+		DestinationForm: "exit-form",
+	}
+	if err := db.CreateBail(context.Background(), bailWithoutEvents); err != nil {
+		t.Fatalf("CreateBail failed: %v", err)
+	}
+
+	older := &BailEvent{
+		BailID:             &bailWithEvents.ID,
+		UserID:             userID,
+		BailName:           bailWithEvents.Name,
+		EventType:          "execution",
+		UsersMatched:       5,
+		UsersBailed:        5,
+		DefinitionSnapshot: def,
+	}
+	if err := db.RecordEvent(context.Background(), older); err != nil {
+		t.Fatalf("RecordEvent failed: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	newest := &BailEvent{
+		BailID:             &bailWithEvents.ID,
+		UserID:             userID,
+		BailName:           bailWithEvents.Name,
+		EventType:          "execution",
+		UsersMatched:       9,
+		UsersBailed:        9,
+		DefinitionSnapshot: def,
+	}
+	if err := db.RecordEvent(context.Background(), newest); err != nil {
+		t.Fatalf("RecordEvent failed: %v", err)
+	}
+
+	// Empty input -> empty map, no error.
+	empty, err := db.GetLatestEventSummariesByBailIDs(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GetLatestEventSummariesByBailIDs(nil) failed: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("Expected empty map for nil input, got %d entries", len(empty))
+	}
+
+	got, err := db.GetLatestEventSummariesByBailIDs(context.Background(), []uuid.UUID{bailWithEvents.ID})
+	if err != nil {
+		t.Fatalf("GetLatestEventSummariesByBailIDs failed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Expected 1 entry, got %d", len(got))
+	}
+	summary, ok := got[bailWithEvents.ID]
+	if !ok {
+		t.Fatalf("Expected entry for bail %s", bailWithEvents.ID)
+	}
+	if summary.ID != newest.ID {
+		t.Errorf("Expected most recent event %s, got %s", newest.ID, summary.ID)
+	}
+	if summary.UsersMatched != 9 || summary.UsersBailed != 9 {
+		t.Errorf("Expected users_matched=9 and users_bailed=9, got matched=%d bailed=%d", summary.UsersMatched, summary.UsersBailed)
+	}
+
+	// Query both bails: only the one with events should be present.
+	all, err := db.GetLatestEventSummariesByBailIDs(context.Background(), []uuid.UUID{
+		bailWithEvents.ID,
+		bailWithoutEvents.ID,
+	})
+	if err != nil {
+		t.Fatalf("GetLatestEventSummariesByBailIDs multiple bails failed: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("Expected 1 entry (only bail with events), got %d", len(all))
+	}
+	if _, ok := all[bailWithoutEvents.ID]; ok {
+		t.Error("Expected no entry for bail without events")
+	}
+}

--- a/exodus/types/types.go
+++ b/exodus/types/types.go
@@ -419,6 +419,18 @@ type BailEvent struct {
 	ExecutionResults   *json.RawMessage `json:"execution_results,omitempty"`
 }
 
+// BailEventSummary is a lightweight projection of the most recent bail event
+// used by the bail list endpoint. It omits the large audit fields that are not
+// needed for the UI.
+type BailEventSummary struct {
+	ID           uuid.UUID  `json:"id"`
+	BailID       *uuid.UUID `json:"bail_id,omitempty"`
+	EventType    string     `json:"event_type"`
+	Timestamp    time.Time  `json:"timestamp"`
+	UsersMatched int        `json:"users_matched"`
+	UsersBailed  int        `json:"users_bailed"`
+}
+
 // Validate checks if the BailEvent is valid
 func (be *BailEvent) Validate() error {
 	if be.UserID == uuid.Nil {


### PR DESCRIPTION
The previous batched latest-event lookup (8276e15) still selected heavy JSON audit columns (definition_snapshot, error, execution_results) for every candidate row. After execution_results was added, the query was no longer fully covered by idx_bail_events_bail and had to do primary-table lookups. For users with large accumulated immediate-bail history, this exceeded the 10s API deadline again.\n\nThis change introduces a lightweight BailEventSummary projection used only by the list endpoint. It selects only the fields the UI needs (timestamp, users_matched, users_bailed) and is fully covered by the existing index. Get/Create/Update endpoints continue to return the full BailEvent.\n\n- Add db.BailEventSummary and GetLatestEventSummariesByBailIDs\n- Add types.BailEventSummary and api.BailListItemResponse\n- Update ListBails to use the summary query\n- Update tests and documentation