### PR TITLE
fix(dean): scope timeout retry cap to this-wait timeout events (VIR-8 hotfix)

### DIFF
--- a/dean/queries.go
+++ b/dean/queries.go
@@ -189,7 +189,22 @@ func Timeouts(cfg *Config, conn *pgxpool.Pool) <-chan *ExternalEvent {
                 WHERE
                   surv.created <= s.form_start_time AND
                   current_state = 'WAIT_EXTERNAL_EVENT' AND
-                  jsonb_array_length(COALESCE(s.state_json->'externalEvents','[]'::jsonb)) < $3
+                  -- Cap timeout RETRIES for this wait. externalEvents is a shared,
+                  -- never-drained log that also holds unrelated events (e.g.
+                  -- moviehouse:* video events), so its total length is the wrong
+                  -- proxy: a user who watched a clip is falsely counted as having
+                  -- exhausted their timeout attempts. Count only the timeout events
+                  -- Dean itself emitted for THIS wait (value == waitStart). The
+                  -- key-existence test short-circuits the ~99% of rows with no log.
+                  (
+                    NOT (s.state_json ? 'externalEvents')
+                    OR (
+                      SELECT count(*)
+                      FROM jsonb_array_elements(s.state_json->'externalEvents') e
+                      WHERE e->'event'->>'type' = 'timeout'
+                        AND e->'event'->>'value' = s.state_json->>'waitStart'
+                    ) < $3
+                  )
               )
               SELECT waitStart, userid, pageid
               FROM timeout_dates

--- a/dean/queries_test.go
+++ b/dean/queries_test.go
@@ -953,24 +953,39 @@ func TestGetTimeoutsIgnoresThoseAtOrAboveCap(t *testing.T) {
 		"bar",
 		ts,
 		"WAIT_EXTERNAL_EVENT",
+		// 5 timeout events already emitted for THIS wait (value == waitStart) =>
+		// retry cap reached. (Previously modeled as opaque [1,2,3,4,5]; the gate
+		// now counts timeout attempts for this wait, not total externalEvents.)
 		fmt.Sprintf(`{"state": "WAIT_EXTERNAL_EVENT",
                       "forms": ["short1"],
-                      "waitStart": %v,
-                      "md": { "startTime": %v },
-                      "externalEvents": [1, 2, 3, 4, 5],
-                      "wait": { "type": "timeout", "value": "20 minutes"}}`, ms, ms))
+                      "waitStart": %[1]v,
+                      "md": { "startTime": %[1]v },
+                      "externalEvents": [
+                        {"event":{"type":"timeout","value":%[1]v}},
+                        {"event":{"type":"timeout","value":%[1]v}},
+                        {"event":{"type":"timeout","value":%[1]v}},
+                        {"event":{"type":"timeout","value":%[1]v}},
+                        {"event":{"type":"timeout","value":%[1]v}}
+                      ],
+                      "wait": { "type": "timeout", "value": "20 minutes"}}`, ms))
 
 	mustExec(t, pool, insertQuery,
 		"under_cap",
 		"bar",
 		ts,
 		"WAIT_EXTERNAL_EVENT",
+		// 4 timeout attempts for THIS wait => still under the cap of 5.
 		fmt.Sprintf(`{"state": "WAIT_EXTERNAL_EVENT",
                       "forms": ["short1"],
-                      "waitStart": %v,
-                      "md": { "startTime": %v },
-                      "externalEvents": [1, 2, 3, 4],
-                      "wait": { "type": "timeout", "value": "20 minutes"}}`, ms, ms))
+                      "waitStart": %[1]v,
+                      "md": { "startTime": %[1]v },
+                      "externalEvents": [
+                        {"event":{"type":"timeout","value":%[1]v}},
+                        {"event":{"type":"timeout","value":%[1]v}},
+                        {"event":{"type":"timeout","value":%[1]v}},
+                        {"event":{"type":"timeout","value":%[1]v}}
+                      ],
+                      "wait": { "type": "timeout", "value": "20 minutes"}}`, ms))
 
 	cfg := &Config{TimeoutMaxPast: "48 hours", TimeoutMaxAttempts: 5}
 	ch := Timeouts(cfg, pool)

--- a/dean/timeout_video_repro_test.go
+++ b/dean/timeout_video_repro_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// waitJSONRelative1Week is the exact prod wait shape armed by the
+// `thank_you_timeout_mentality` statement in the MENtality incentive form.
+const waitJSONRelative1Week = `"wait": { "type": "timeout", "value": { "type": "relative", "timeout": "1 week" } }`
+
+// fiveMoviehouseEvents are 5 synthetic video-player events (verbatim shape from
+// prod state_json->externalEvents) accumulated earlier in the survey and never
+// drained from the shared log.
+const fiveMoviehouseEvents = `[
+	{"source":"synthetic","event":{"type":"external","value":{"id":"1195793007","type":"moviehouse:play"}}},
+	{"source":"synthetic","event":{"type":"external","value":{"id":"1195793007","type":"moviehouse:heartbeat"}}},
+	{"source":"synthetic","event":{"type":"external","value":{"id":"1195793007","type":"moviehouse:heartbeat"}}},
+	{"source":"synthetic","event":{"type":"external","value":{"id":"1195793007","type":"moviehouse:seeked"}}},
+	{"source":"synthetic","event":{"type":"external","value":{"id":"1195793007","type":"moviehouse:pause"}}}
+]`
+
+// TestGetTimeouts_MaturedTimeoutFiresDespitePriorVideoEvents is the regression
+// test for Linear VIR-8 ("Stuck in MENtality Incentive").
+//
+// A respondent parks at a matured 1-week timeout after watching a moviehouse
+// video earlier in the survey. Before the fix, Dean's gate counted the TOTAL
+// length of the shared, never-drained externalEvents log, so the unrelated
+// video events falsely exhausted the DEAN_TIMEOUT_MAX_ATTEMPTS budget and the
+// timeout was never fired — leaving the user parked, never stitching to endline.
+//
+// After the fix (count only `timeout` events emitted for THIS wait), the video
+// events no longer count, so the matured timeout fires normally.
+func TestGetTimeouts_MaturedTimeoutFiresDespitePriorVideoEvents(t *testing.T) {
+	pool := testPool()
+	defer pool.Close()
+	before(pool)
+
+	// waitStart 7d12h ago => "1 week" timeout matured ~12h ago: matured and
+	// within the 72h MaxPast window.
+	waitStart := time.Now().UTC().Add(-(7*24 + 12) * time.Hour)
+	ws := waitStart.Unix() * 1000
+	updated := time.Now().UTC().Add(-30 * time.Minute)
+
+	mustExec(t, pool, insertUserSql)
+	mustExec(t, pool, pageInsertSql, `{"id": "bar"}`)
+	mustExec(t, pool, surveyInsertSql, "mentalityincentive", time.Now().UTC().Add(-30*24*time.Hour), "{}")
+
+	// STUCK user: matured timeout + 5 prior moviehouse events.
+	mustExec(t, pool, insertQuery, "stuck", "bar", updated, "WAIT_EXTERNAL_EVENT",
+		fmt.Sprintf(`{"state":"WAIT_EXTERNAL_EVENT","forms":["mentalityincentive"],"waitStart":%v,"md":{"startTime":%v},%v,"externalEvents":%v}`,
+			ws, ws, waitJSONRelative1Week, fiveMoviehouseEvents))
+
+	// CONTROL user: identical matured timeout, no video events.
+	mustExec(t, pool, insertQuery, "control", "bar", updated, "WAIT_EXTERNAL_EVENT",
+		fmt.Sprintf(`{"state":"WAIT_EXTERNAL_EVENT","forms":["mentalityincentive"],"waitStart":%v,"md":{"startTime":%v},%v,"externalEvents":[]}`,
+			ws, ws, waitJSONRelative1Week))
+
+	// Non-empty blacklist => Dean's no-LIMIT branch (as in prod, which has a
+	// populated DEAN_TIMEOUT_BLACKLIST), so every eligible user is returned
+	// rather than a single ORDER BY ... LIMIT 1 row.
+	cfg := &Config{TimeoutMaxPast: "72 hours", TimeoutMaxAttempts: 5, TimeoutBlacklist: []string{"some-other-form"}}
+	events := getEvents(Timeouts(cfg, pool))
+
+	fired := map[string]bool{}
+	for _, e := range events {
+		fired[e.User] = true
+	}
+	t.Logf("Dean fired timeouts for: %v", fired)
+
+	assert.True(t, fired["control"], "control user with a matured timeout should fire")
+	assert.True(t, fired["stuck"],
+		"FIXED (VIR-8): matured timeout must fire even though prior moviehouse video "+
+			"events sit in externalEvents — they are not timeout attempts and must not count")
+}
+
+// TestGetTimeouts_RetryCapStillStopsAfterMaxTimeoutAttempts pins the ORIGINAL
+// intent of the gate: Dean must stop re-firing a timeout that never resolves,
+// after DEAN_TIMEOUT_MAX_ATTEMPTS synthetic timeout events for this wait. This
+// guards against the fix accidentally removing the retry cap.
+func TestGetTimeouts_RetryCapStillStopsAfterMaxTimeoutAttempts(t *testing.T) {
+	pool := testPool()
+	defer pool.Close()
+	before(pool)
+
+	waitStart := time.Now().UTC().Add(-(7*24 + 12) * time.Hour)
+	ws := waitStart.Unix() * 1000
+	updated := time.Now().UTC().Add(-30 * time.Minute)
+
+	mustExec(t, pool, insertUserSql)
+	mustExec(t, pool, pageInsertSql, `{"id": "bar"}`)
+	mustExec(t, pool, surveyInsertSql, "mentalityincentive", time.Now().UTC().Add(-30*24*time.Hour), "{}")
+
+	// 5 timeout events already emitted for THIS wait (value == waitStart).
+	fiveTimeoutAttempts := fmt.Sprintf(`[
+		{"source":"synthetic","event":{"type":"timeout","value":%[1]v}},
+		{"source":"synthetic","event":{"type":"timeout","value":%[1]v}},
+		{"source":"synthetic","event":{"type":"timeout","value":%[1]v}},
+		{"source":"synthetic","event":{"type":"timeout","value":%[1]v}},
+		{"source":"synthetic","event":{"type":"timeout","value":%[1]v}}
+	]`, ws)
+
+	// exhausted: already retried 5 times -> must NOT fire again.
+	mustExec(t, pool, insertQuery, "exhausted", "bar", updated, "WAIT_EXTERNAL_EVENT",
+		fmt.Sprintf(`{"state":"WAIT_EXTERNAL_EVENT","forms":["mentalityincentive"],"waitStart":%v,"md":{"startTime":%v},%v,"externalEvents":%v}`,
+			ws, ws, waitJSONRelative1Week, fiveTimeoutAttempts))
+
+	cfg := &Config{TimeoutMaxPast: "72 hours", TimeoutMaxAttempts: 5, TimeoutBlacklist: []string{"some-other-form"}}
+	events := getEvents(Timeouts(cfg, pool))
+
+	fired := map[string]bool{}
+	for _, e := range events {
+		fired[e.User] = true
+	}
+	assert.False(t, fired["exhausted"],
+		"retry cap must still stop firing after DEAN_TIMEOUT_MAX_ATTEMPTS timeout events for this wait")
+}


### PR DESCRIPTION
## Production hotfix — Linear VIR-8 (MENtality incentive users stuck, not stitching to endline)

### Root cause
Dean's timeout-selection gate used `jsonb_array_length(externalEvents) < DEAN_TIMEOUT_MAX_ATTEMPTS (5)` as a proxy for "timeout retry attempts". But `externalEvents` is a **shared, never-drained** log that also holds unrelated events — notably `moviehouse:*` video-player events from earlier in the survey. Respondents who watched a video clip arrived at their later 1-week timeout wait already showing ≥5 events, so Dean silently excluded them, never emitted the synthetic timeout, and they stayed parked forever.

Verified read-only against prod: Dean's timeout query returned **0** actionable users; all ~21 matured/in-window users failed the `<5` gate, **19 of 21** specifically due to moviehouse events.

### Fix
Count only the timeout events Dean emitted for the **current** wait (`event.type='timeout' AND value == waitStart`) instead of the whole log. Retry cap preserved; unrelated events no longer consume it. Unbounded growth stays independently bounded by the spammer gate (`externalEvents > 100 → BLOCK_USER`).

Dean-query-only: no state-shape change, no migration.

### Tests
- `TestGetTimeouts_MaturedTimeoutFiresDespitePriorVideoEvents` — matured timeout now fires despite 5 prior moviehouse events (control + stuck both fire).
- `TestGetTimeouts_RetryCapStillStopsAfterMaxTimeoutAttempts` — cap still stops after 5 timeout attempts for the wait.
- Updated `TestGetTimeoutsIgnoresThoseAtOrAboveCap` to model attempts as real timeout events.

All 11 timeout tests pass. (Pre-existing, unrelated `TestGetPaymentsGetsOnlyThoseWhovePassedGraceButNotInterval` failure reproduces on untouched `main` — not part of this change.)

### Deploy
Dean is **not** part of the `-wa` platform rebuild; identical on `main` and prod tag `dean-v0.0.41`. After merge: tag `dean-v0.0.43` → build → bump `production.yaml` `versionDean` → `helm upgrade -n vprod`. Staging follows after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)