### PR TITLE
deploy(prod): bump dean to v0.0.43 (VIR-8 timeout fix)

### DIFF
--- a/devops/values/production.yaml
+++ b/devops/values/production.yaml
@@ -24,7 +24,7 @@ versionDashboard: &vdashboard v0.0.66
 versionBotserver: &vbotserver v0.0.12
 versionReplybot: &vreplybot v0.0.203
 versionLinksniffer: &vlinksniffer v0.0.6
-versionDean: &vdean v0.0.41
+versionDean: &vdean v0.0.43
 versionScribble: &vscribble v0.0.32
 versionDinersclub: &vdinersclub v0.0.40
 versionFormcentral: &vformcentral v0.0.12


### PR DESCRIPTION
Ships PR #138 (Dean timeout retry-cap fix) to production. Dean-only bump v0.0.41 → v0.0.43. No `-wa` tags. Follows tag `dean-v0.0.43`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)