### PR TITLE
chore(prod): reconcile versionReplybot 203 → 204 to match live vprod

### DIFF
--- a/devops/values/production.yaml
+++ b/devops/values/production.yaml
@@ -22,7 +22,7 @@ commandsTopic: &commandstopic "vlab-prod-commands"
 
 versionDashboard: &vdashboard v0.0.66
 versionBotserver: &vbotserver v0.0.12
-versionReplybot: &vreplybot v0.0.203
+versionReplybot: &vreplybot v0.0.204
 versionLinksniffer: &vlinksniffer v0.0.6
 versionDean: &vdean v0.0.43
 versionScribble: &vscribble v0.0.32


### PR DESCRIPTION
production.yaml lagged live: gbv-replybot runs v0.0.204 but the values file declared v0.0.203. Bumps the declaration to match live (no cluster change) so a helm upgrade won't downgrade replybot. All other prod versions already match live; dean stays v0.0.43 (pending timeout-fix deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)