### PR TITLE
deploy(staging): bump dean to v0.0.44-wa (VIR-8 fix on -wa line)

### DIFF
--- a/devops/values/staging.yaml
+++ b/devops/values/staging.yaml
@@ -25,7 +25,7 @@ versionBotserver: &vbotserver v0.0.12
 versionHermes: &vhermes v0.0.1-wa
 versionReplybot: &vreplybot v0.0.208-wa
 versionLinksniffer: &vlinksniffer v0.0.6
-versionDean: &vdean v0.0.41
+versionDean: &vdean v0.0.44-wa
 versionScribble: &vscribble v0.0.32
 versionDinersclub: &vdinersclub v0.0.41-wa
 versionFormcentral: &vformcentral v0.0.12


### PR DESCRIPTION
Moves staging dean v0.0.41 → v0.0.44-wa: the VIR-8 timeout retry-cap fix cherry-picked onto the -wa platform line (dean-v0.0.42-wa → dean-v0.0.44-wa). All 11 timeout tests pass with the platform threading. Dean was the last staging component still on non-wa. Image built from tag dean-v0.0.44-wa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)