### PR TITLE
ci(go): unbreak test_dinersclub and test_formcentral

### DIFF
--- a/dinersclub/Dockerfile.dev
+++ b/dinersclub/Dockerfile.dev
@@ -1,9 +1,16 @@
-FROM golang:alpine3.18
+# Pin the Go minor, not the Alpine release: go.mod requires >= 1.24 and the
+# image runs with GOTOOLCHAIN=local, so an image older than go.mod fails at
+# `go mod download` rather than fetching a newer toolchain. `golang:alpine3.18`
+# floated to go 1.22.3 and broke CI the moment go.mod moved to 1.24. Matches
+# ./Dockerfile, which already pins 1.24-alpine and leaves librdkafka-dev
+# unpinned -- the =2.1.1-r0 pin was only valid for Alpine 3.18's package index.
+FROM golang:1.24-alpine
 RUN apk add --no-cache \
         gcc \
         libc-dev \
-        librdkafka-dev=2.1.1-r0 \
-        pkgconf
+        librdkafka-dev \
+        pkgconf \
+        readline-dev
 
 
 RUN mkdir /app
@@ -11,5 +18,12 @@ COPY go.mod /app
 WORKDIR /app
 
 RUN go mod download
-RUN go get -u github.com/nathany/looper
-RUN go install github.com/nathany/looper
+
+# looper drives the live-reload dev loop only; CI (--is-ci) never invokes it.
+# It was installed with `go get -u`, which resolves the LATEST version of every
+# transitive dep into this module's graph — so an unrelated upstream release
+# breaks the image. That is what happened: golang.org/x/sys v0.47.0 now requires
+# go >= 1.25, failing the build under any older toolchain. `go install pkg@ver`
+# resolves against looper's own go.mod in isolation and cannot drag this
+# module's dependencies forward. Pinned, so a new upstream release is inert.
+RUN go install github.com/nathany/looper@v0.3.3

--- a/dinersclub/dingconnect_test.go
+++ b/dinersclub/dingconnect_test.go
@@ -14,6 +14,15 @@ import (
 	dingconnect "github.com/vlab-research/go-dingconnect"
 )
 
+// setDefaultEnv sets key only when it is not already present, so a caller that
+// has configured the environment (docker compose in CI) wins over the local
+// default.
+func setDefaultEnv(key, value string) {
+	if _, ok := os.LookupEnv(key); !ok {
+		os.Setenv(key, value)
+	}
+}
+
 func init() {
 	// Set required environment variables for tests that use getConfig()
 	os.Setenv("CACHE_TTL", "1h")
@@ -21,12 +30,19 @@ func init() {
 	os.Setenv("CACHE_MAX_COST", "10000")
 	os.Setenv("CACHE_BUFFER_ITEMS", "64")
 	os.Setenv("CHATBASE_DATABASE", "chatroach")
-	os.Setenv("CHATBASE_HOST", "localhost")
-	// 5433 is the canonical test database: `make test-db` in devops/ creates it
-	// (devops/Makefile PORT=5433) and every other module targets it. 26257 came
-	// from ./.env, i.e. the production port -- pointing the suite at whatever
-	// happened to be listening there.
-	os.Setenv("CHATBASE_PORT", "5433")
+	// Host and port are DEFAULTS, not overrides -- the repo has two test-database
+	// conventions and the suite has to satisfy both:
+	//
+	//   local:  `make test-db` in devops/ runs CockroachDB on localhost:5433
+	//           (devops/Makefile PORT=5433), and nothing sets these vars.
+	//   CI:     ./test.sh runs dinersclub/test.yaml, whose compose network puts
+	//           CockroachDB at cockroachdb:26257 and exports it in the env.
+	//
+	// Setting them unconditionally pinned the suite to the local convention and
+	// broke test_dinersclub on CircleCI, where 26257 is the compose service --
+	// not, as previously noted here, the production port.
+	setDefaultEnv("CHATBASE_HOST", "localhost")
+	setDefaultEnv("CHATBASE_PORT", "5433")
 	os.Setenv("CHATBASE_USER", "root")
 	os.Setenv("CHATBASE_MAX_CONNECTIONS", "10")
 	os.Setenv("KAFKA_BROKERS", "localhost:9092")

--- a/dinersclub/test.yaml
+++ b/dinersclub/test.yaml
@@ -44,7 +44,7 @@ services:
     networks:
       - fly
   initdb:
-    image: cockroachdb/cockroach:v21.2.17
+    image: cockroachdb/cockroach:v24.1.28
     depends_on:
       - cockroachdb
     entrypoint: |
@@ -59,7 +59,7 @@ services:
     networks:
       - fly
   cockroachdb:
-    image: cockroachdb/cockroach:v21.2.17
+    image: cockroachdb/cockroach:v24.1.28
     command: start-single-node --insecure
     ports:
       - 26257:26257

--- a/formcentral/Dockerfile.dev
+++ b/formcentral/Dockerfile.dev
@@ -1,4 +1,8 @@
-FROM golang:alpine
+# Pin the Go minor rather than floating on `golang:alpine`: go.mod requires
+# >= 1.24, and the image runs with GOTOOLCHAIN=local, so an image that drifts
+# either side of go.mod fails at `go mod download`. ./Dockerfile already pins
+# 1.24-alpine; this now matches it.
+FROM golang:1.24-alpine
 
 RUN apk add --no-cache \
     gcc \
@@ -10,4 +14,11 @@ COPY go.mod /app
 WORKDIR /app
 
 RUN go mod download
-RUN go get -u github.com/nathany/looper
+
+# looper drives the live-reload dev loop only; CI (--is-ci) never invokes it.
+# `go get -u` resolved the LATEST version of every transitive dep into this
+# module's graph, so an unrelated upstream release breaks the image --
+# golang.org/x/sys v0.47.0 now requires go >= 1.25. `go install pkg@ver`
+# resolves against looper's own go.mod in isolation and is pinned, so a new
+# upstream release is inert.
+RUN go install github.com/nathany/looper@v0.3.3

--- a/formcentral/test.yaml
+++ b/formcentral/test.yaml
@@ -47,7 +47,7 @@ services:
     networks:
       - fly
   initdb:
-    image: cockroachdb/cockroach:v21.2.17
+    image: cockroachdb/cockroach:v24.1.28
     depends_on:
       - cockroachdb
     entrypoint: |
@@ -63,7 +63,7 @@ services:
     networks:
       - fly
   cockroachdb:
-    image: cockroachdb/cockroach:v21.2.17
+    image: cockroachdb/cockroach:v24.1.28
     command: start-single-node --insecure
     ports:
       - 26257:26257

--- a/formcentral/test_helpers.go
+++ b/formcentral/test_helpers.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"testing"
 
 	"github.com/jackc/pgconn"
@@ -24,13 +26,43 @@ func before(t *testing.T, pool *pgxpool.Pool) {
 	}
 }
 
+// testConfig points the suite at whichever test database is available. The repo
+// has two conventions and this has to satisfy both:
+//
+//	local: `make test-db` in devops/ runs CockroachDB on localhost:5433
+//	       (devops/Makefile PORT=5433) and sets no environment.
+//	CI:    ./test.sh runs formcentral/test.yaml, whose compose network puts
+//	       CockroachDB at cockroachdb:26257 and exports CHATBASE_HOST/PORT.
+//
+// Hardcoding localhost:5433 pinned this to the local convention, so
+// test_formcentral could never pass on CircleCI -- it dialled [::1]:5433 inside
+// a container where nothing listens. Env wins; the local values are defaults.
 func testConfig() *Config {
 	return &Config{
 		DbName:     "chatroach",
-		DbHost:     "localhost",
-		DbPort:     5433,
-		DbUser:     "root",
+		DbHost:     envOr("CHATBASE_HOST", "localhost"),
+		DbPort:     envOrInt("CHATBASE_PORT", 5433),
+		DbUser:     envOr("CHATBASE_USER", "root"),
 		DbMaxConns: 10,
 		Port:       8000,
 	}
+}
+
+func envOr(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+func envOrInt(key string, fallback int) int {
+	v, ok := os.LookupEnv(key)
+	if !ok || v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return n
 }


### PR DESCRIPTION
Both CircleCI Go jobs were failing, for **three** independent reasons. Companion to #143, which fixes `replybot-test`.

Each fix only revealed the next: the images couldn't build, so CI never got far enough to try pulling a database, so the DB host was never even reached.

## 1. Dev images floated on the Go version while go.mod pinned it

`dinersclub/Dockerfile.dev` used `golang:alpine3.18`, formcentral's used `golang:alpine`. Neither pins a Go minor, both run with `GOTOOLCHAIN=local`, and both modules declare `go 1.24`:

```
go: go.mod requires go >= 1.24 (running go 1.22.3; GOTOOLCHAIN=local)
```

Both now pin `1.24-alpine`, matching each service's **own production Dockerfile**. dinersclub's `librdkafka-dev=2.1.1-r0` pin went with it — that exact-version pin only resolved against Alpine 3.18's index, and `./Dockerfile` already leaves it unpinned. dinersclub also gains `readline-dev`, which looper needs and formcentral already installed.

## 2. `go get -u` made both images time bombs

looper drives the live-reload dev loop and is **never invoked under `--is-ci`**, but `go get -u` resolves the *latest* version of every transitive dependency into the module graph — so an unrelated upstream release breaks the build. One did:

```
go: golang.org/x/sys@v0.47.0 requires go >= 1.25.0 (running go 1.24.13)
```

Pinning Go to 1.24 alone therefore still failed. Now `go install github.com/nathany/looper@v0.3.3`, which resolves against looper's own go.mod in isolation and is pinned, so the next upstream release is inert.

## 3. The test suites hardcoded the local test-database convention

The repo has two, and the Go tests only honoured one:

| | database | used by |
|---|---|---|
| local | `localhost:5433` | `make test-db` (`devops/Makefile PORT=5433`), sets no env |
| CI | `cockroachdb:26257` | `./test.sh` → `<app>/test.yaml`, exports `CHATBASE_HOST`/`PORT` |

`formcentral/test_helpers.go` hardcoded `localhost:5433`, so `test_formcentral` could never pass on CircleCI — it dialled `[::1]:5433` inside a container where nothing listens. `dinersclub/dingconnect_test.go` set the same values via `os.Setenv` in `init()`, overriding what compose had already exported correctly; its comment called 26257 "the production port", but under `test.yaml` it is the compose service.

Both now treat the local values as **defaults** and let an existing environment win.

## 4. The pinned CockroachDB image no longer exists

```
manifest for cockroachdb/cockroach:v21.2.17 not found: manifest unknown
```

Cockroach Labs removed the tag, so `run initdb` never started a database. **This passes on an unfixed local checkout** — v21.2.17 is still in most developers' image cache and docker only consults the registry on a miss, which is why it wasn't caught before the first push. Verified by deleting the tag locally: registry says manifest unknown; `v24.1.28` pulls clean.

Moved to `v24.1.28` — what `devops/Makefile` (`DB_VERSION`) already uses for `make test-db`, and what production runs. Local, CI and prod now agree on one version, and `devops/migrations` is already exercised against it by `make test-db`.

## Verification

Exact CircleCI commands, each from a clean state, after every fix:

```
./test.sh dinersclub  --is-ci   ->  EXIT=0   ok  github.com/vlab-research/dinersclub   2.271s
./test.sh formcentral --is-ci   ->  EXIT=0   ok  github.com/vlab-research/formcentral  0.565s
```

Both now **SUCCESS on CircleCI** on this branch. No `go.mod`/`go.sum` changes — the containerised `go mod tidy` left the module files untouched.

## Not fixed here

`test_e2e` fails on every branch including main, at a different layer — Helm times out bootstrapping the full stack into kind:

```
Release "fly" does not exist. Installing it now.
Error: context deadline exceeded
make: *** [Makefile:62: bootstrap-fly] Error 1
```

Separate problem, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrTQ71XhpBp678wC3TB5CF