### PR TITLE
deploy: replybot v0.0.215 — reproducible image, no code change

### DIFF
--- a/devops/values/production.yaml
+++ b/devops/values/production.yaml
@@ -40,7 +40,7 @@ commandsTopic: &commandstopic "vlab-prod-commands"
 versionDashboard: &vdashboard v0.0.71
 versionBotserver: &vbotserver v0.0.12
 versionHermes: &vhermes v0.0.3-wa
-versionReplybot: &vreplybot v0.0.214
+versionReplybot: &vreplybot v0.0.215
 versionLinksniffer: &vlinksniffer v0.0.6
 versionDean: &vdean v0.0.44-wa
 versionScribble: &vscribble v0.0.32

--- a/devops/values/staging.yaml
+++ b/devops/values/staging.yaml
@@ -24,12 +24,17 @@ versionDashboard: &vdashboard v0.0.68-wa
 versionBotserver: &vbotserver v0.0.12
 versionHermes: &vhermes v0.0.3-wa
 # replybot leaves the -wa line here (was v0.0.211-wa, which trailed prod's
-# v0.0.213). v0.0.214 is a clean tag, so staging catches up by three releases:
-# v0.0.212 (quick-reply referral) and v0.0.213 (utility_message repeat), both
-# already prod-validated, plus the md-durability fix. Per
+# v0.0.213). v0.0.215 is a clean tag, so staging catches up by v0.0.212
+# (quick-reply referral) and v0.0.213 (utility_message repeat) — both already
+# prod-validated — plus the md-durability fix. Per
 # documentation/staging-tagging-and-deploy.md, swap each remaining -wa service
 # to a clean tag as it next changes.
-versionReplybot: &vreplybot v0.0.214
+#
+# v0.0.215 carries no code change over v0.0.214. It exists because v0.0.214 was
+# built before the lockfile landed, so its image came from `npm install` against
+# floating ^ ranges and cannot be reproduced from source. v0.0.215 is the first
+# replybot image built with `npm ci` against a committed package-lock.json.
+versionReplybot: &vreplybot v0.0.215
 versionLinksniffer: &vlinksniffer v0.0.6
 versionDean: &vdean v0.0.44-wa
 versionScribble: &vscribble v0.0.32


### PR DESCRIPTION
Version bump only — **no code change over v0.0.214**.

## Why

v0.0.214 was tagged before #143 merged, so its image was built by `npm install` against `package.json` alone. **13 of replybot's 15 runtime deps are floating `^` ranges**, so that build resolved them from the registry at build time and the image cannot be reproduced — rebuilding the v0.0.214 tag on another day can yield different dependency versions.

v0.0.215 is the first replybot image built with `npm ci` against the committed lockfile. Its contents are derivable from the repo, and a rollback to it restores known bytes.

## Deploy delta

| namespace | replybot | also picks up |
|---|---|---|
| vprod | v0.0.213 → v0.0.215 | dinersclub v0.0.43-wa → v0.0.45 |
| vstag | v0.0.211-wa → v0.0.215 | dinersclub v0.0.43-wa → v0.0.45 |

The dinersclub ride-along was already committed to both values files and is **entirely DingConnect-scoped** — `dingconnect.go`, its tests, a new `secrets.go` used by nothing else, and the `go-dingconnect` dependency. No other payment provider is touched. Confirmed OK to ride along.

Staging additionally leaves the `-wa` line, picking up v0.0.212 (quick-reply referral) and v0.0.213 (utility_message repeat) on the way; both already run in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrTQ71XhpBp678wC3TB5CF