### PR TITLE
deploy: hold dinersclub at v0.0.43-wa until DingConnect is live

### DIFF
--- a/devops/values/production.yaml
+++ b/devops/values/production.yaml
@@ -44,7 +44,16 @@ versionReplybot: &vreplybot v0.0.215
 versionLinksniffer: &vlinksniffer v0.0.6
 versionDean: &vdean v0.0.44-wa
 versionScribble: &vscribble v0.0.32
-versionDinersclub: &vdinersclub v0.0.45
+# HELD AT v0.0.43-wa (2026-08-05). v0.0.45 is built and its code is on main,
+# but DingConnect is not operational yet: v0.0.45 resolves DingConnect
+# credentials from Generic Secrets and deliberately stops honouring the legacy
+# entity='dingconnect' credential (see TestDingConnectAuth_IgnoresLegacyEntity),
+# so deploying it before the secrets are seeded would break DingConnect
+# payments. Nothing else in the v0.0.43-wa..v0.0.45 range touches any other
+# provider -- the diff is dingconnect.go, its tests, a new secrets.go used by
+# nothing else, and the go-dingconnect dep -- so holding it costs nothing.
+# Bump to v0.0.45 when DingConnect is ready to go live.
+versionDinersclub: &vdinersclub v0.0.43-wa
 versionFormcentral: &vformcentral v0.0.14-wa
 versionExporter: &vexporter v0.6.10
 versionExodus: &vexodus v0.2.3

--- a/devops/values/staging.yaml
+++ b/devops/values/staging.yaml
@@ -38,7 +38,16 @@ versionReplybot: &vreplybot v0.0.215
 versionLinksniffer: &vlinksniffer v0.0.6
 versionDean: &vdean v0.0.44-wa
 versionScribble: &vscribble v0.0.32
-versionDinersclub: &vdinersclub v0.0.45
+# HELD AT v0.0.43-wa (2026-08-05). v0.0.45 is built and its code is on main,
+# but DingConnect is not operational yet: v0.0.45 resolves DingConnect
+# credentials from Generic Secrets and deliberately stops honouring the legacy
+# entity='dingconnect' credential (see TestDingConnectAuth_IgnoresLegacyEntity),
+# so deploying it before the secrets are seeded would break DingConnect
+# payments. Nothing else in the v0.0.43-wa..v0.0.45 range touches any other
+# provider -- the diff is dingconnect.go, its tests, a new secrets.go used by
+# nothing else, and the go-dingconnect dep -- so holding it costs nothing.
+# Bump to v0.0.45 when DingConnect is ready to go live.
+versionDinersclub: &vdinersclub v0.0.43-wa
 versionFormcentral: &vformcentral v0.0.14-wa
 versionExporter: &vexporter v0.6.10
 versionExodus: &vexodus v0.2.3


### PR DESCRIPTION
Makes the next `helm upgrade` ship **replybot and nothing else**.

## Why

`0fbe0dea` bumped `versionDinersclub` to v0.0.45 in both values files, but it was never applied — so the version has sat ahead of the cluster since. That made it a silent passenger: `helm upgrade` acts on the whole release, so deploying replybot would have shipped dinersclub too.

DingConnect isn't operational yet, and v0.0.45 is exactly the commit that switches its credential resolution to Generic Secrets — **deliberately** dropping the legacy `entity='dingconnect'` credential (`TestDingConnectAuth_IgnoresLegacyEntity` pins that behaviour). Deploying it before the secrets are seeded would break DingConnect payments rather than merely not help.

## What this does

Pins both files back to `v0.0.43-wa` — what both clusters actually run — so the values files describe live state again. The code stays on main, the image stays built; only the deployment waits.

A comment at each site records why and what unblocks it, so the next person to see `43-wa` next to a published `45` doesn't read it as drift and "fix" it.

## Blast radius of holding: nil

The whole `v0.0.43-wa..v0.0.45` range is DingConnect-scoped — `dingconnect.go`, its tests, a new `secrets.go` referenced by nothing else, and the `go-dingconnect` dep. No other provider is touched. And `DINERSCLUB_PROVIDERS` in both envs is `"fake,reloadly,giftcard,http"` — dingconnect isn't in the enabled list at all.

## Verified

`helm template` against each values file, diffed against the live images:

```
vprod    replybot  v0.0.213     ->  v0.0.215
vstag    replybot  v0.0.211-wa  ->  v0.0.215
```

Exactly one image changes per namespace. Nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrTQ71XhpBp678wC3TB5CF